### PR TITLE
fix links and refs for repo move to wegue-oss org

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Template and re-usable components for webmapping applications with OpenLayers an
 
 <img align="left" style="padding-bottom: 20px;" src="screenshots/wegue-app-1.png" />
 
-Go to the online demo at https://meggsimum.github.io/wegue/
+Go to the online demo at https://wegue-oss.github.io/wegue/
 
 ## About
 Wegue (**We**b**G**IS with OpenLayers and V**ue**) combines the power of [Vue.js](https://vuejs.org/) and the geospatial savvy of [OpenLayers](https://openlayers.org) to make lightweight webmapping applications. For styling and pre-defined UI-components the Material Design
@@ -124,11 +124,11 @@ docker build -t meggsimum/wegue:latest .
 
 ## Developing online using Gitpod.io
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/meggsimum/wegue/)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/wegue-oss/wegue/)
 
 Gitpod.io is an online IDE using VS Code that also provides a terminal and enables live preview. A registration is required but can be done with a GitHub account.
 
-Open [gitpod.io/#https://github.com/meggsimum/wegue/](https://gitpod.io/#https://github.com/meggsimum/wegue/) to get started.
+Open [gitpod.io/#https://github.com/wegue-oss/wegue/](https://gitpod.io/#https://github.com/wegue-oss/wegue/) to get started.
 
 Wegue will automatically be initiated and your Wegue application can be previewed in a pane of the online IDE. The live preview of Wegue can also be seen in another browser tab by prefixing your workspace sub-URL with `8081-`. For example  `https://8081-YOUR-WORKSPACE-NAME.ws-eu25.gitpod.io`.
 

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -4,7 +4,7 @@
 
 ![](_media/cover.gif)
 
-[GitHub](https://github.com/meggsimum/wegue)
+[GitHub](https://github.com/wegue-oss/wegue)
 [Demo](https://apps.meggsimum.de/wegue-demos/global/)
 [Quickstart](?id=quickstart)
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -10,7 +10,7 @@ Wegue (**We**b**G**IS with OpenLayers and V**ue**) combines the power of [Vue.js
 Clone the repository
 
 ```shell
-git clone https://github.com/meggsimum/wegue
+git clone https://github.com/wegue-oss/wegue
 cd wegue
 ```
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,8 +16,8 @@
       loadSidebar: true,
       homepage: 'home.md',
       name: 'Wegue',
-      repo: 'https://github.com/meggsimum/wegue',
-      basePath: 'https://meggsimum.github.io/wegue',
+      repo: 'https://github.com/wegue-oss/wegue',
+      basePath: 'https://wegue-oss.github.io/wegue',
       themeColor: '#cc0000'
     }
   </script>

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -102,7 +102,7 @@ To simplify the theming configuration, if the "themes" property isn't configured
 | onprimary     |  no | white if primary is a dark color. <br/> black if primary is a light color     |
 | onsecondary   |  no | white if secondary is a dark color. <br/> black if secondary is a light color |
 
-Note that there is a clear asymmetry in the "light" and "dark" theme configuration. In the "light" theme, the primary color is mandatory and all the 
+Note that there is a clear asymmetry in the "light" and "dark" theme configuration. In the "light" theme, the primary color is mandatory and all the
 others are derived from that. In the "dark" theme, the predominant color must be a shade of black (to comply with the [material design specification](https://material.io/design/color/dark-theme.html)), so the primary color is locked to `#272727`. Therefore, in this case the colors are derived from the second predominant color.
 
 #### Tips on creating a color theme
@@ -133,7 +133,7 @@ Wegue uses the secondary color to accent selected parts of the UI. Everything be
 
 The "on" colors are additional UI colors placed over the main colors. Wegue uses this class of colors to improve the legibility of typography/iconography over primary and secondary colors.
 
-The rule of thumb is simple: 
+The rule of thumb is simple:
 * if the main color is a dark tone, white or the 50 tone of the main color are safe choices;
 * if the main color is a light tone, black or the 700 tone of the main color.
 
@@ -306,7 +306,7 @@ Below is an example for a sidebar configuration object:
 ```
 
 ### overviewMap
-Wegue integrates an overview map control, if the optional `overviewMap` property is declared. 
+Wegue integrates an overview map control, if the optional `overviewMap` property is declared.
 
 The `overviewMap` object supports the following properties:
 
@@ -637,6 +637,6 @@ Example configurations can be found in the `app-starter/static` directory. Below
 ```
 
 More elaborate examples can be found in the app-starter directory.
-* [app-conf-projected.json](https://github.com/meggsimum/wegue/blob/master/app-starter/static/app-conf-projected.json) demonstrates custom Projections and Tilegrids.
-* [app-conf-minimal.json](https://github.com/meggsimum/wegue/blob/master/app-starter/static/app-conf-minimal.json) is a minimal setup for a Wegue application.
-* [app-conf-sidebar.json](https://github.com/meggsimum/wegue/blob/master/app-starter/static/app-conf-sidebar.json) is an example for displaying module content inside a sidebar.
+* [app-conf-projected.json](https://github.com/wegue-oss/wegue/blob/master/app-starter/static/app-conf-projected.json) demonstrates custom Projections and Tilegrids.
+* [app-conf-minimal.json](https://github.com/wegue-oss/wegue/blob/master/app-starter/static/app-conf-minimal.json) is a minimal setup for a Wegue application.
+* [app-conf-sidebar.json](https://github.com/wegue-oss/wegue/blob/master/app-starter/static/app-conf-sidebar.json) is an example for displaying module content inside a sidebar.

--- a/docs/workshop.md
+++ b/docs/workshop.md
@@ -1,6 +1,6 @@
 # Workshop
 
-This workshop uses Wegue version [`v1.0.0`](https://github.com/meggsimum/wegue/releases/tag/v1.0.0) but works for higher versions with no or little adaptation.
+This workshop uses Wegue version [`v1.0.0`](https://github.com/wegue-oss/wegue/releases/tag/v1.0.0) but works for higher versions with no or little adaptation.
 
 ## Prerequisites
 
@@ -12,7 +12,7 @@ You should have basic knowledge of using a commandline and a basic understanding
 
 For this workshop or to quickly try something, you can use the online-environment Gitpod. For this you need a browser and you need to register at Gitpod. That can be done with an existing GitHub account.
 
-To get started navigate to [**gitpod.io/#https://github.com/meggsimum/wegue/tree/v1.0.0**](https://gitpod.io/#https://github.com/meggsimum/wegue/tree/v1.0.0). Ideally, you will see a terminal running commands to set up Wegue. After some moments (~1 minute) you should see a running Wegue instance in one of the editor's panes like in this screenshot.
+To get started navigate to [**gitpod.io/#https://github.com/wegue-oss/wegue/tree/v1.0.0**](https://gitpod.io/#https://github.com/wegue-oss/wegue/tree/v1.0.0). Ideally, you will see a terminal running commands to set up Wegue. After some moments (~1 minute) you should see a running Wegue instance in one of the editor's panes like in this screenshot.
 
 ![Wegue running in Gitpod](_media/workshop/gitpod-wegue.png)
 
@@ -31,7 +31,7 @@ We need to download Wegue. This can be done in two ways:
     # cd /ENTER/A/LOCATION/FOR/THE/CODE
 
     # clone the Wegue git repository
-    git clone https://github.com/meggsimum/wegue
+    git clone https://github.com/wegue-oss/wegue
 
     # enter the Wegue directory
     cd wegue
@@ -40,7 +40,7 @@ We need to download Wegue. This can be done in two ways:
     git checkout v1.0.0
     ```
 
-- Alternatively download a zip-archive of Wegue via GitHub using this [link](https://github.com/meggsimum/wegue/archive/refs/tags/v1.0.0.zip) and extract it.
+- Alternatively download a zip-archive of Wegue via GitHub using this [link](https://github.com/wegue-oss/wegue/archive/refs/tags/v1.0.0.zip) and extract it.
 
 ## Start Wegue
 
@@ -178,7 +178,7 @@ Here you can change the text elements, for example to this:
 
 At the moment we have one layer in our `app-conf.json`. It is defined in the property `mapLayers` as one item of an array. Before we add a new layer, let's try to understand the structure of a layer object by checking our current layer:
 
-- `"type": "XYZ"` defines the type of the layer. Wegue supports many other types like `WMS`, `WFS`, or `VECTOR` (see the [layer docs](https://meggsimum.github.io/wegue/#/map-layer-configuration) for details)
+- `"type": "XYZ"` defines the type of the layer. Wegue supports many other types like `WMS`, `WFS`, or `VECTOR` (see the [layer docs](https://wegue-oss.github.io/wegue/#/map-layer-configuration) for details)
 - `"name": "Carto Positron"` the layer name used in the UI, so visible to the user
 - `"url": "https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"` is the URL where the data of the layer comes from
 - `"lid": "positron"` defines a "layer ID", this is necessary to uniquely reference a layer
@@ -221,7 +221,7 @@ Add our new layer object before the previous layer and ensure both layer objects
 
 Refresh your map in the browser and you should see the airport of Frankfurt in the lower left part of the map indicated by a blue circle. Admittedly, the airport is difficult to recognize. A more prominent styling would be great!
 
-We can do this by adding the property `style` to our layer object. There are multiple options for styling vector layers (see the [style docs](https://meggsimum.github.io/wegue/#/map-layer-configuration?id=style-for-vectorlayers) for details). A common option is to define a circle. It will show a black circle with a white stroke:
+We can do this by adding the property `style` to our layer object. There are multiple options for styling vector layers (see the [style docs](https://wegue-oss.github.io/wegue/#/map-layer-configuration?id=style-for-vectorlayers) for details). A common option is to define a circle. It will show a black circle with a white stroke:
 
 ```json
   "style": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "contributors": [
     {
       "name": "See github contributors",
-      "url": "https://github.com/meggsimum/wegue/graphs/contributors"
+      "url": "https://github.com/wegue-oss/wegue/graphs/contributors"
     }
   ],
   "private": true,


### PR DESCRIPTION
Good to see the move to the `wegue-oss` GH org! This PR fixes some/hope all remaining references to the original repo i.e. changing `github.com/meggsimum/wegue` to `github.com/wegue-oss/wegue` , including the github.io pages and Gitpod.