### PR TITLE
Allow rendering of HTML in PropertyTable

### DIFF
--- a/src/components/infoclick/PropertyTable.vue
+++ b/src/components/infoclick/PropertyTable.vue
@@ -7,8 +7,7 @@
           <td class="key-td">
             {{key}}
           </td>
-          <td class="val-td">
-            {{value}}
+          <td class="val-td" v-html="value">
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
This allows the rendering of HTML in the value column of the `PropertyTable`. Normal (non-html) text is rendered as before, so we have backward compatibility here. No need for updates of existing apps.