### PR TITLE
Add event 'sidebar-toggle' to programmatically toggle sidebar visibility

### DIFF
--- a/app-starter/components/AppSidebar.vue
+++ b/app-starter/components/AppSidebar.vue
@@ -47,6 +47,9 @@ export default {
     WguEventBus.$on('sidebar-scroll', comp => {
       this.scrollTo(comp);
     });
+    WguEventBus.$on('sidebar-toggle', () => {
+      this.sidebarOpen = !this.sidebarOpen;
+    });
   },
   methods: {
     /**


### PR DESCRIPTION
This adds a hook to programmatically toggle the open state of the `AppSidebar`. It is implemented as event `'sidebar-toggle'`, on which the `AppSidebar` listens to. So every emit of 'sidebar-toggle' over the WguEventBus (`WguEventBus.$emit('sidebar-toggle');`) toggles the visibility of the sidebar.

Resolves #301 

