### PR TITLE
Additional HTTP params for WMS layers

### DIFF
--- a/docs/map-layer-configuration.md
+++ b/docs/map-layer-configuration.md
@@ -99,10 +99,11 @@ The following properties can be applied to all map layer types
 | hoverable           | Boolean value, whether the features of the layer can be hovered in order to display information in a tooltip. The WMS must support `GetFeatureInfo` requests to obtain feature information. Wegue's default hover tooltip renders a single feature attribute which has to be declared by `hoverAttribute`. You can also choose to implement a custom overlay declared by `hoverOverlay` to render multiple feature attributes in a custom tooltip. | `"hoverable": true` |
 | hoverAttribute      | Attribute to be shown if a feature of the layer is hovered. Only has an effect if `hoverable` is set to `true`.  | `"hoverAttribute": "name"` |
 | hoverOverlay        | ID of a custom map overlay to display when a feature of the layer is hovered. Only has an effect if `hoverable` is set to `true`. For more information on how to implement a map overlay see the [reusable components](reusable-components?id=map-overlay) section. | `"hoverOverlay": "my-custom-overlay"` |
+| additionalParams        | This allows to inject custom HTTP parameters to the GetMap request of the layer. | `"additionalParams": {"FEATUREID": 1}"` |
 
 ## WMS (image)
 
-Similar properties as Tiled WMS, with these exceptions: 
+Similar properties as Tiled WMS, with these exceptions:
 
 | Property           | Meaning   | Example |
 |--------------------|:---------:|---------|

--- a/docs/map-layer-configuration.md
+++ b/docs/map-layer-configuration.md
@@ -99,7 +99,7 @@ The following properties can be applied to all map layer types
 | hoverable           | Boolean value, whether the features of the layer can be hovered in order to display information in a tooltip. The WMS must support `GetFeatureInfo` requests to obtain feature information. Wegue's default hover tooltip renders a single feature attribute which has to be declared by `hoverAttribute`. You can also choose to implement a custom overlay declared by `hoverOverlay` to render multiple feature attributes in a custom tooltip. | `"hoverable": true` |
 | hoverAttribute      | Attribute to be shown if a feature of the layer is hovered. Only has an effect if `hoverable` is set to `true`.  | `"hoverAttribute": "name"` |
 | hoverOverlay        | ID of a custom map overlay to display when a feature of the layer is hovered. Only has an effect if `hoverable` is set to `true`. For more information on how to implement a map overlay see the [reusable components](reusable-components?id=map-overlay) section. | `"hoverOverlay": "my-custom-overlay"` |
-| additionalParams        | This allows to inject custom HTTP parameters to the GetMap request of the layer. | `"additionalParams": {"FEATUREID": 1}"` |
+| params        | This allows to inject custom HTTP parameters to the GetMap request of the layer. | `"params": {"FEATUREID": 1}"` |
 
 ## WMS (image)
 

--- a/src/factory/Layer.js
+++ b/src/factory/Layer.js
@@ -115,7 +115,7 @@ export const LayerFactory = {
   createImageWmsLayer (lConf) {
     // apply additional HTTP params
     const params = { 'LAYERS': lConf.layers };
-    ObjectUtil.mergeDeep(params, lConf.additionalParams);
+    ObjectUtil.mergeDeep(params, lConf.params);
 
     const layer = new ImageLayer({
       ...this.getCommonLayerOptions(lConf),
@@ -145,7 +145,7 @@ export const LayerFactory = {
   createTileWmsLayer (lConf) {
     // apply additional HTTP params
     const params = { 'LAYERS': lConf.layers };
-    ObjectUtil.mergeDeep(params, lConf.additionalParams);
+    ObjectUtil.mergeDeep(params, lConf.params);
 
     const layer = new TileLayer({
       ...this.getCommonLayerOptions(lConf),

--- a/src/factory/Layer.js
+++ b/src/factory/Layer.js
@@ -19,6 +19,7 @@ import { OlStyleFactory } from './OlStyle'
 import { applyTransform } from 'ol/extent';
 import { getTransform } from 'ol/proj';
 import axios from 'axios';
+import ObjectUtil from '../util/Object';
 
 /**
  * Factory, which creates OpenLayers layer instances according to a given config
@@ -112,13 +113,15 @@ export const LayerFactory = {
    * @return {ol.layer.Image} OL WMS layer instance
    */
   createImageWmsLayer (lConf) {
+    // apply additional HTTP params
+    const params = { 'LAYERS': lConf.layers };
+    ObjectUtil.mergeDeep(params, lConf.additionalParams);
+
     const layer = new ImageLayer({
       ...this.getCommonLayerOptions(lConf),
       source: new ImageWMS({
         url: lConf.url,
-        params: {
-          'LAYERS': lConf.layers
-        },
+        params: params,
         serverType: lConf.serverType,
         ratio: lConf.ratio,
         interpolate: lConf.interpolate,
@@ -140,13 +143,15 @@ export const LayerFactory = {
    * @return {ol.layer.Tile} OL Tiled WMS layer instance
    */
   createTileWmsLayer (lConf) {
+    // apply additional HTTP params
+    const params = { 'LAYERS': lConf.layers };
+    ObjectUtil.mergeDeep(params, lConf.additionalParams);
+
     const layer = new TileLayer({
       ...this.getCommonLayerOptions(lConf),
       source: new TileWmsSource({
         url: lConf.url,
-        params: {
-          'LAYERS': lConf.layers
-        },
+        params: params,
         serverType: lConf.serverType,
         tileGrid: lConf.tileGrid,
         projection: lConf.projection,

--- a/test/unit/specs/factory/Layer.spec.js
+++ b/test/unit/specs/factory/Layer.spec.js
@@ -65,11 +65,16 @@ describe('LayerFactory', () => {
         'attribution': 'Kindly provided by @ahocevar',
         'isBaseLayer': false,
         'visibility': false,
-        'displayInLayerList': true
+        'displayInLayerList': true,
+        'additionalParams': {
+          'foo': 'bar-tile'
+        }
       };
       const layer = LayerFactory.createTileWmsLayer(layerConf);
       expect(layer instanceof TileLayer).to.equal(true);
       expect(layer.getSource() instanceof TileWmsSource);
+      expect(layer.getSource().getParams().LAYERS).to.equal('topp:states');
+      expect(layer.getSource().getParams().foo).to.equal('bar-tile');
     });
 
     it('createImageWmsLayer returns correct layer instance', () => {
@@ -85,11 +90,16 @@ describe('LayerFactory', () => {
         'attribution': 'Kindly provided by @ahocevar',
         'isBaseLayer': false,
         'visibility': false,
-        'displayInLayerList': true
+        'displayInLayerList': true,
+        'additionalParams': {
+          'foo': 'bar-image'
+        }
       };
       const layer = LayerFactory.createImageWmsLayer(layerConf);
       expect(layer instanceof ImageLayer).to.equal(true);
       expect(layer.getSource() instanceof ImageWMS);
+      expect(layer.getSource().getParams().LAYERS).to.equal('ne:ne_10m_populated_places');
+      expect(layer.getSource().getParams().foo).to.equal('bar-image');
     });
 
     it('createWfsLayer returns correct layer instance', () => {

--- a/test/unit/specs/factory/Layer.spec.js
+++ b/test/unit/specs/factory/Layer.spec.js
@@ -66,7 +66,7 @@ describe('LayerFactory', () => {
         'isBaseLayer': false,
         'visibility': false,
         'displayInLayerList': true,
-        'additionalParams': {
+        'params': {
           'foo': 'bar-tile'
         }
       };
@@ -91,7 +91,7 @@ describe('LayerFactory', () => {
         'isBaseLayer': false,
         'visibility': false,
         'displayInLayerList': true,
-        'additionalParams': {
+        'params': {
           'foo': 'bar-image'
         }
       };


### PR DESCRIPTION
This adds the optional config option `params` for `'TILEWMS' `and `'IMAGEWMS'` layers. This allows to inject custom HTTP parameters to the GetMap request of the layer.

This is useful to set custom (non-standardized) WMS request parameters, such as `CQL_FILTER` or `FEATUREID`, which are e.g. supported by the GeoServer WMS implementation or the `angle` parameter of the UMN Mapserver software.