### PR TITLE
Fix typo in lid for vector tiles layer

### DIFF
--- a/app-starter/locales/de.json
+++ b/app-starter/locales/de.json
@@ -28,7 +28,7 @@
     "ahocevar-imagewms": {
       "name": "Image WMS (ahocevar)"
     },
-    "ahocevar-vectortyle": {
+    "ahocevar-vectortiles": {
       "name": "Vector Tile Layer"
     },
     "opentopomap": {

--- a/app-starter/locales/en.json
+++ b/app-starter/locales/en.json
@@ -28,7 +28,7 @@
     "ahocevar-imagewms": {
       "name": "Image WMS (ahocevar)"
     },
-    "ahocevar-vectortyle": {
+    "ahocevar-vectortiles": {
       "name": "Vector Tile Layer"
     },
     "opentopomap": {

--- a/app-starter/static/app-conf-sidebar.json
+++ b/app-starter/static/app-conf-sidebar.json
@@ -182,7 +182,7 @@
     },
     {
       "type": "VECTORTILE",
-      "lid": "ahocevar-vectortyle",
+      "lid": "ahocevar-vectortiles",
       "url": "https://ahocevar.com/geoserver/gwc/service/tms/1.0.0/ne:ne_10m_admin_0_countries@EPSG%3A900913@pbf/{z}/{x}/{-y}.pbf",
       "format": "MVT",
       "visible": false,

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -176,7 +176,7 @@
     },
     {
       "type": "VECTORTILE",
-      "lid": "ahocevar-vectortyle",
+      "lid": "ahocevar-vectortiles",
       "url": "https://ahocevar.com/geoserver/gwc/service/tms/1.0.0/ne:ne_10m_admin_0_countries@EPSG%3A900913@pbf/{z}/{x}/{-y}.pbf",
       "format": "MVT",
       "attribution": "Kindly provided by @ahocevar",

--- a/docs/language-packs.md
+++ b/docs/language-packs.md
@@ -122,7 +122,7 @@ Below is an example configuration for an English language pack.
     "ahocevar-imagewms": {
       "name": "Image WMS (ahocevar)"
     },
-    "ahocevar-vectortyle": {
+    "ahocevar-vectortiles": {
       "name": "Vector Tile Layer"
     },
     "opentopomap": {

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -561,7 +561,7 @@ Example configurations can be found in the `app-starter/static` directory. Below
     },
     {
       "type": "VECTORTILE",
-      "lid": "ahocevar-vectortyle",
+      "lid": "ahocevar-vectortiles",
       "url": "https://ahocevar.com/geoserver/gwc/service/tms/1.0.0/ne:ne_10m_admin_0_countries@EPSG%3A900913@pbf/{z}/{x}/{-y}.pbf",
       "format": "MVT",
       "attribution": "Kindly provided by @ahocevar",


### PR DESCRIPTION
Minor typo correction within the `lid` of the vector tiles layer in the `app-starter` package and update of the corresponding docs. No functional change.