### PR TITLE
Resizable sidebar

### DIFF
--- a/app-starter/components/AppSidebar.vue
+++ b/app-starter/components/AppSidebar.vue
@@ -78,22 +78,21 @@ export default {
      * Resize the sidebar, if the 'resizable' option is enabled.
      */
     onResize () {
-      const me = this;
-      const sidebarEl = me.$refs.sidebar.$el;
+      const sidebarEl = this.$refs.sidebar.$el;
       sidebarEl.style.transition = 'initial';
 
       // Resize on mouse move
-      function onMouseMove (e) {
+      const onMouseMove = (e) => {
         document.body.style.cursor = 'ew-resize';
         let w = e.clientX;
-        w = Number.isNaN(me.minWidth) ? w : Math.max(me.minWidth, w);
-        w = Number.isNaN(me.maxWidth) ? w : Math.min(me.maxWidth, w);
-        me.sidebarWidth = w;
+        w = Number.isNaN(this.minWidth) ? w : Math.max(this.minWidth, w);
+        w = Number.isNaN(this.maxWidth) ? w : Math.min(this.maxWidth, w);
+        this.sidebarWidth = w;
       }
       document.addEventListener('mousemove', onMouseMove, false);
 
       // Stop the interaction on the next mouse up.
-      function onMouseUp () {
+      const onMouseUp = () => {
         sidebarEl.style.transition = '';
         document.body.style.cursor = '';
         document.removeEventListener('mousemove', onMouseMove, false);

--- a/app-starter/components/AppSidebar.vue
+++ b/app-starter/components/AppSidebar.vue
@@ -1,9 +1,10 @@
 <template>
   <v-navigation-drawer
       class="wgu-app-sidebar"
+      ref="sidebar"
       app
       clipped
-      :width=width
+      :width=sidebarWidth
       v-model="sidebarOpen"
       >
       <!-- Forward the default slot for sidebar content. -->
@@ -20,24 +21,33 @@
           <v-icon color="onsecondary" v-else>chevron_right</v-icon> 
         </v-btn>
       </template>
+      <!-- Invisible sidebar resizer -->
+      <div v-if="resizable"
+        class="wgu-app-sidebar-resizer"
+        @mousedown.prevent="onResize"
+      /> 
   </v-navigation-drawer>
 </template>
 
 <script>
 
-import { WguEventBus } from '../../src/WguEventBus'
+import { WguEventBus } from '../../src/WguEventBus';
 
 export default {
   name: 'wgu-app-sidebar',
   props: {
     width: { type: Number, required: false, default: 400 },
+    minWidth: { type: Number, required: false, default: NaN },
+    maxWidth: { type: Number, required: false, default: NaN },
     visible: { type: Boolean, required: false, default: true },
     autoScroll: { type: Boolean, required: false, default: true },
-    scrollDuration: { type: Number, required: false, default: 500 }
+    scrollDuration: { type: Number, required: false, default: 500 },
+    resizable: { type: Boolean, required: false, default: false }
   },
   data () {
     return {
-      sidebarOpen: this.visible
+      sidebarOpen: this.visible,
+      sidebarWidth: this.width
     }
   },
   /**
@@ -63,6 +73,32 @@ export default {
           duration: this.scrollDuration
         });
       }
+    },
+    /**
+     * Resize the sidebar, if the 'resizable' option is enabled.
+     */
+    onResize () {
+      const me = this;
+      const sidebarEl = me.$refs.sidebar.$el;
+      sidebarEl.style.transition = 'initial';
+
+      // Resize on mouse move
+      function onMouseMove (e) {
+        document.body.style.cursor = 'ew-resize';
+        let w = e.clientX;
+        w = Number.isNaN(me.minWidth) ? w : Math.max(me.minWidth, w);
+        w = Number.isNaN(me.maxWidth) ? w : Math.min(me.maxWidth, w);
+        me.sidebarWidth = w;
+      }
+      document.addEventListener('mousemove', onMouseMove, false);
+
+      // Stop the interaction on the next mouse up.
+      function onMouseUp () {
+        sidebarEl.style.transition = '';
+        document.body.style.cursor = '';
+        document.removeEventListener('mousemove', onMouseMove, false);
+      }
+      document.addEventListener('mouseup', onMouseUp, { once: true });
     }
   }
 }

--- a/app-starter/static/app-conf-sidebar.json
+++ b/app-starter/static/app-conf-sidebar.json
@@ -52,8 +52,11 @@
   "sidebar": {
     "visible": true,
     "width": 400,
+    "minWidth": 400,
+    "maxWidth": 600,
     "autoScroll": true,
-    "scrollDuration": 500
+    "scrollDuration": 500,
+    "resizable": true
   },
 
   "mapLayers": [

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -310,9 +310,12 @@ The `sidebar` object supports the following properties:
 | Property           | Meaning   | Example |
 |--------------------|:---------:|---------|
 | width              | Width of the sidebar in pixels. Defaults to 400px.  | `"width": 400` |
+| minWidth           | Minimal width of the sidebar in pixels. This option will only take effect if the `resizable` option is enabled. | `"minWidth": 400` |
+| maxWidth           | Maximal width of the sidebar in pixels. This option will only take effect if the `resizable` option is enabled.   | `"maxWidth": 600` |
 | visible            | Specifies whether the sidebar appears in open or closed state on application start. Defaults to true. | `"visible": true` |
 | autoScroll         | Whether to automatically scroll the sidebar to the active module. Defaults to true. | `"autoScroll": true` |
 | scrollDuration     | Animation duration in milliseconds to automatically scroll the sidebar to the active module. Defaults to 500ms. | `"scrollDuration": 500` |
+| resizable          | Specifies whether the sidebar's width can be adjusted. Defaults to false. | `"resizable": true`
 
 Below is an example for a sidebar configuration object:
 
@@ -320,8 +323,11 @@ Below is an example for a sidebar configuration object:
   "sidebar": {
     "visible": true,
     "width": 400,
+    "minWidth": 400,
+    "maxWidth": 600,
     "autoScroll": true,
-    "scrollDuration": 500
+    "scrollDuration": 500,
+    "resizable": true,
   }
 ```
 

--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -159,6 +159,16 @@ html {
   border-radius: 0px 4px 4px 0px;
 }
 
+.wgu-app-sidebar-resizer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: 5px;
+  cursor: ew-resize;
+  z-index: 10000;
+}
+
 /* Temporary fix for buggy word-breaking in vuetify card texts and titles.
   This will go away in a future vuetify version - 
   see https://github.com/vuetifyjs/vuetify/issues/9130 */

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -65,7 +65,18 @@ export default {
     // already been fired. Don not use directly in cmps, use Mapable instead.
     Vue.prototype.$map = me.map;
 
-    me.map.setTarget(document.getElementById('ol-map-container'));
+    // Set the target for the OL canvas and tie it`s size to ol-map-container.
+    // Remarks: 'ol-map-container' does not exist in the scope of the current unit test,
+    //  therefore flag the initialization to prevent errors.
+    const container = document.getElementById('ol-map-container');
+    if (container) {
+      me.map.setTarget(container);
+
+      const resizeObserver = new ResizeObserver(() => {
+        me.map.updateSize();
+      });
+      resizeObserver.observe(container);
+    }
 
     // Send the event 'ol-map-mounted' with the OL map as payload
     WguEventBus.$emit('ol-map-mounted', me.map);
@@ -75,9 +86,6 @@ export default {
     //  If so, a better implementation could be to rely on this.$nextTick(), which currently causes trouble
     //  for the units tests (deferred operations are invoked after the component has already been destroyed).
     me.timerHandle = setTimeout(() => {
-      // resize the map, so it fits to parent
-      me.map.updateSize();
-
       // adjust the bg color of the OL buttons (like zoom, rotate north, ...)
       me.setOlButtonColor();
     }, 200);

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -67,7 +67,7 @@ export default {
 
     // Set the target for the OL canvas and tie it`s size to ol-map-container.
     // Remarks: 'ol-map-container' does not exist in the scope of the current unit test,
-    //  therefore flag the initialization to prevent errors.
+    // therefore flag the initialization to prevent errors.
     const container = document.getElementById('ol-map-container');
     if (container) {
       me.map.setTarget(container);


### PR DESCRIPTION
This pull request adds additional options to the sidebar configuration to make it resizable on behalf of the user - a resizer appears when hovering the right edge of the sidebar.

Enable the option in app.conf (defaults to false):
```
"sidebar": {
    "resizable": true
}
```

Set additional resizing constraints (no restrictions per default)
```
"sidebar": {
    "minWidth": 400,
    "maxWidth": 600
}
```

A technical note:
To resize the OL map canvas automatically when it`s container size changes, I hooked up a [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) in Map component. This should have sufficient browser support by now. It also fires initially so the workaround on application start has been removed.
This also means we can remove other map-resize related code like in attributeTable. I will provide those with a couple of fixes in an upcoming PR.

Merry christmas to all of you!

