### PR TITLE
Configure "X" button to close module windows

### DIFF
--- a/app-starter/static/app-conf-sidebar.json
+++ b/app-starter/static/app-conf-sidebar.json
@@ -223,7 +223,8 @@
       "win": "sidebar",
       "icon": "layers",
       "visible": true,
-      "minimizable": true
+      "minimizable": true,
+      "closable": false
     },
     "wgu-measuretool": {
       "target": "menu",

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -181,7 +181,7 @@
       "format": "MVT",
       "attribution": "Kindly provided by @ahocevar",
       "visible": false,
-      "opacityControl": true,  
+      "opacityControl": true,
       "style": {
         "strokeColor": "gray",
         "strokeWidth": 1,
@@ -287,7 +287,8 @@
     "sample-module": {
       "target": "toolbar",
       "win": "floating",
-      "icon": "star"
+      "icon": "star",
+      "closable": false
     }
   }
 }

--- a/docs/module-configuration.md
+++ b/docs/module-configuration.md
@@ -22,6 +22,7 @@ The following properties can be applied to all module types:
 | **win**            | Value to mark if the module has a window as sub component and where to show the module UI elements. Valid options are `floating` and `sidebar`. If the value is omitted, then the module is not associated with a window.  | `"win": "floating"` |
 | icon               | Provide a customized icon for the module. | `"icon": "info"` |
 | minimizable        | Indicates whether the module window can be minimized. Only applies if a module window is present as indicated by the `win` parameter. | `"minimizable": true` |
+| closable           | Indicates whether the module window can be closed by a "X" icon in the window's header bar. Only applies if a module window is present as indicated by the `win` parameter. | `"closable": false` |
 | backgroundImage    | Optional background image for the window header. Only applies if a module window is present as indicated by the `win` parameter. | `"backgroundImage": "static/icon/myImage.png"}` |
 | visible            | Configures the initial visiblity of a module window on application start. Only applies if a module window is present as indicated by the `win` parameter.  | `"visible": true` |
 

--- a/src/components/modulecore/ModuleCard.vue
+++ b/src/components/modulecore/ModuleCard.vue
@@ -1,11 +1,11 @@
 <template>
-  <v-card :class="cardClasses" 
+  <v-card :class="cardClasses"
     :style="cardStyles"
     v-bind="cardAttr"
     v-if=show
     v-draggable-win="cardDraggable"
-    > 
-    
+    >
+
     <v-img :src="backgroundImage">
       <v-toolbar v-bind="toolbarAttr">
         <v-icon color="onprimary" class="mr-4">{{ icon }}</v-icon>
@@ -16,18 +16,18 @@
         <slot name="wgu-win-toolbar"></slot>
 
         <v-spacer></v-spacer>
-        <v-btn color="onprimary" v-if="minimizable" icon small 
+        <v-btn color="onprimary" v-if="minimizable" icon small
           @click="minimized = !minimized">
-          <v-icon v-if="minimized">web_asset</v-icon> 
+          <v-icon v-if="minimized">web_asset</v-icon>
           <v-icon v-else>remove</v-icon>
         </v-btn>
-        <v-btn color="onprimary" icon small class="mr-0" 
+        <v-btn color="onprimary" v-if="closable" icon small class="mr-0"
           @click="toggleUi">
           <v-icon>close</v-icon>
         </v-btn>
       </v-toolbar>
     </v-img>
-    
+
     <!-- Default slot for module content -->
     <div v-show="!minimized">
       <slot name="default"></slot>
@@ -51,6 +51,7 @@
       icon: { type: String, required: true },
       win: { type: String, required: false, default: 'floating' },
       minimizable: { type: Boolean, required: false, default: false },
+      closable: { type: Boolean, required: false, default: true },
       backgroundImage: { type: String, required: false, default: undefined },
       visible: { type: Boolean, required: false, default: false },
       // Positioning / sizing properties will be ignored for sidebar cards.


### PR DESCRIPTION
This introduces the module config property `closable` in order to configure whether the module window can be closed by a "X" icon in the window's header bar or not. The default is `true`, so previous behavior (always render the X icon) is not changed for existing configurations.