### PR TITLE
Show perimeter of measure polygon

### DIFF
--- a/src/components/measuretool/MeasureResult.vue
+++ b/src/components/measuretool/MeasureResult.vue
@@ -35,6 +35,11 @@ export default {
       if (geom instanceof PolygonGeom) {
         output = me.formatArea(geom);
         me.area = output;
+
+        // perimeter of  outer LinearRing of measure polygon
+        me.distance = me.formatLength(new LineStringGeom(
+          geom.getLinearRing(0).getCoordinates()
+        ));
       } else if (geom instanceof LineStringGeom) {
         output = me.formatLength(geom);
         me.distance = output;

--- a/src/components/measuretool/MeasureResult.vue
+++ b/src/components/measuretool/MeasureResult.vue
@@ -36,7 +36,7 @@ export default {
         output = me.formatArea(geom);
         me.area = output;
 
-        // perimeter of  outer LinearRing of measure polygon
+        // perimeter of outer LinearRing of measure polygon
         me.distance = me.formatLength(new LineStringGeom(
           geom.getLinearRing(0).getCoordinates()
         ));

--- a/tests/unit/specs/components/measuretool/MeasureResult.spec.js
+++ b/tests/unit/specs/components/measuretool/MeasureResult.spec.js
@@ -70,6 +70,7 @@ describe('measuretool/MeasureResult.vue', () => {
       comp.setProps({ measureGeom: { geom: polyGeom } });
       comp.vm.$nextTick(() => {
         expect(comp.vm.area).to.equal('1 m²');
+        expect(comp.vm.distance).to.equal('4 m');
         done();
       });
     });


### PR DESCRIPTION
Shows the perimeter of the measured polygon in the measure module by taking the outer `LinearRing` of the measured polygon.