### PR TITLE
Add icons to MeasureTool type chooser buttons

### DIFF
--- a/docs/module-configuration.md
+++ b/docs/module-configuration.md
@@ -104,6 +104,7 @@ Module identifier: `wgu-measuretool`
 | sketchVertexStrokeColor        | Stroke color of the vertex of the sketch geometry (while measuring). Takes a CSS3 compliant color value. | `"sketchVertexStrokeColor": "#c62828"`. |
 | sketchVertexFillColor          | Fill color of the vertex of the sketch geometry (while measuring). Takes a CSS3 compliant color value | `"sketchVertexFillColor": "rgba(198,40,40,0.2)"`. |
 | showAngleTool                  | Flag to show / hide the angle tool to calculate the azimuth of a drawn 2-point line. | `"showAngleTool": true` |
+| iconsOnly                  | Flag to show / hide the texts in the buttons to choose the measure type. Set to `true` to render icons only. Default is `false`. | `"iconsOnly": true` |
 
 ## ZoomToMaxExtent
 

--- a/src/components/measuretool/MeasureTypeChooser.vue
+++ b/src/components/measuretool/MeasureTypeChooser.vue
@@ -1,16 +1,31 @@
 <template>
 
-  <v-btn-toggle color="secondary"  v-model="measureTypeData" mandatory>
-     <v-btn large value="distance">
-       {{ $t("wgu-measuretool.distance") }}
+  <v-btn-toggle color="secondary" v-model="measureTypeData" mandatory>
+    <v-btn large value="distance">
+      <v-icon>
+        mdi-vector-polyline
+      </v-icon>
+      <span v-if="!iconsOnly">
+        {{ $t("wgu-measuretool.distance") }}
+      </span>
      </v-btn>
      <v-btn large value="area">
-       {{ $t("wgu-measuretool.area") }}
+      <v-icon>
+        mdi-vector-square
+      </v-icon>
+      <span v-if="!iconsOnly">
+        {{ $t("wgu-measuretool.area") }}
+      </span>
      </v-btn>
      <v-btn large value="angle" v-if="showAngleTool">
-       {{ $t("wgu-measuretool.angle") }}
-     </v-btn>
-   </v-btn-toggle>
+      <v-icon>
+        mdi-vector-line
+      </v-icon>
+      <span v-if="!iconsOnly">
+        {{ $t("wgu-measuretool.angle") }}
+      </span>
+    </v-btn>
+  </v-btn-toggle>
 
 </template>
 
@@ -19,7 +34,8 @@ export default {
   name: 'wgu-measure-type-chooser',
   props: {
     measureType: { type: String, default: 'distance' },
-    showAngleTool: { type: Boolean, default: false }
+    showAngleTool: { type: Boolean, default: false },
+    iconsOnly: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/src/components/measuretool/MeasureWin.vue
+++ b/src/components/measuretool/MeasureWin.vue
@@ -11,6 +11,7 @@
       <wgu-measure-type-chooser
         :measureType="measureType"
         :showAngleTool="showAngleTool"
+        :iconsOnly="iconsOnly"
         @wgu-measuretype-change="applyMeasureType"
       />
       </v-card-title>
@@ -40,7 +41,8 @@ export default {
   mixins: [Mapable],
   props: {
     icon: { type: String, required: false, default: 'photo_size_select_small' },
-    showAngleTool: { type: Boolean, required: false, default: false }
+    showAngleTool: { type: Boolean, required: false, default: false },
+    iconsOnly: { type: Boolean, required: false, default: false }
   },
   data () {
     return {


### PR DESCRIPTION
**_This PR is based on #339._** (see this [diff](https://github.com/wegue-oss/wegue/compare/0bd6936f84909b686090fc414750b2ccc6a3cd03...160198747acbc068e331040cca61967f268f3874) for the relevant changeset)

This PR adds icons to the measure type chooser buttons in the `MeasureTool` module:

![image](https://github.com/wegue-oss/wegue/assets/1185547/1f8a0538-2f89-4cc9-b198-1c0ca5f70bd3)

Also adds a module property `iconsOnly` to force showing icons only (no text) for the buttons:

![image](https://github.com/wegue-oss/wegue/assets/1185547/b04b0cb3-0b03-4473-bd11-0523258a0bf8)

The get this set the module property 

`"iconsOnly": true`

in the module config within the `app-conf.json`.