### PR TITLE
Corrected a Nominatim bug shown by unit tests

### DIFF
--- a/src/components/geocoder/providers/osm.js
+++ b/src/components/geocoder/providers/osm.js
@@ -32,7 +32,7 @@ export class OpenStreetMap {
    */
   constructor () {
     this.settings = {
-      url: 'https://nominatim.openstreetmap.org/search/',
+      url: 'https://nominatim.openstreetmap.org/search',
       params: {
         q: '',
         format: 'json',


### PR DESCRIPTION
Hi team,

Since last week, three unit tests have started to fail due to some change in `Nominatim API URLs`.

![before](https://github.com/wegue-oss/wegue/assets/57899415/df7c7e53-aa03-42cf-be52-8b5b073aa72e)

If you visit the `URL` written inside of the `OSM Geocoder provider`, some hints are given:

> Using the URL /search/ and /reverse/ (with slashes) is no longer supported. Please use URLs as given in the documentation.
> ...
> See [github issue #3134](https://github.com/osm-search/Nominatim/issues/3134) for more details.

This small PR corrects this small issue...

Cheers
Sébastien

Edit: As stated in #342, when package-lock.json is regenerated, some of the updated dependencies break a few more unit tests and it seems that `ci-tests` suffer the same problem as this PR works flawlessly at home but has problems when run on `Github` server.

![after](https://github.com/wegue-oss/wegue/assets/57899415/100614fc-877a-4f3d-8781-ce6bd4abecc9)

This could be mitigated by configuring the build step to use `npm ci` instead of `npm i` as summarised, for example, in [this article](https://levelup.gitconnected.com/npm-i-vs-npm-ci-install-node-modules-in-your-app-faster-and-wisely-e5b1bef0f93d) :

> npm ci just installs existing dependencies, in contrast to npm install, which attempts to update current dependencies if possible. This ensures that the builds in continuous integration are reliable. It’s better to use npm i in development and npm ci for production.