### PR TITLE
Geocoding error handling

### DIFF
--- a/src/components/geocoder/GeocoderController.js
+++ b/src/components/geocoder/GeocoderController.js
@@ -76,12 +76,8 @@ export class GeocoderController {
       ajax.callbackName = parameters.callbackName;
     }
 
-    try {
-      const response = await json(ajax);
-      return this.provider.handleResponse(response)
-    } catch (err) {
-      return err
-    }
+    const response = await json(ajax);
+    return this.provider.handleResponse(response)
 
     // // Do the query via Ajax XHR, returning JSON. Async callback via Promise.
     // json(ajax)

--- a/tests/unit/specs/components/geocoder/Geocoder.spec.js
+++ b/tests/unit/specs/components/geocoder/Geocoder.spec.js
@@ -115,6 +115,49 @@ describe('geocoder/Geocoder.vue', () => {
   describe('methods - search', () => {
     let comp;
     let vm;
+    let onQueryResultsSpy;
+    let onQueryErrorSpy;
+    const fetchResults = JSON.stringify([
+      {
+        lon: '7.0928944',
+        lat: '50.7400352',
+        boundingbox: ['50.7399852', '50.7400852', '7.0928444', '7.0929444'],
+        display_name: 'John Barleycorn, 52, Heerstraße, Altstadt, Nordstadt, Stadtbezirk Bonn, Bonn, North Rhine-Westphalia, 53111, Germany',
+        address: {
+          amenity: 'John Barleycorn',
+          house_number: '52',
+          road: 'Heerstraße',
+          neighbourhood: 'Altstadt',
+          quarter: 'Nordstadt',
+          city_district: 'Stadtbezirk Bonn',
+          city: 'Bonn',
+          state: 'North Rhine-Westphalia',
+          'ISO3166-2-lvl4': 'DE-NW',
+          postcode: '53111',
+          country: 'Germany',
+          country_code: 'de'
+        }
+      },
+      {
+        lon: '7.092862308035045',
+        lat: '50.7400625',
+        boundingbox: ['50.7399456', '50.7402129', '7.0926186', '7.0931026'],
+        display_name: '52, Heerstraße, Altstadt, Nordstadt, Stadtbezirk Bonn, Bonn, North Rhine-Westphalia, 53111, Germany',
+        address: {
+          house_number: '52',
+          road: 'Heerstraße',
+          neighbourhood: 'Altstadt',
+          quarter: 'Nordstadt',
+          city_district: 'Stadtbezirk Bonn',
+          city: 'Bonn',
+          state: 'North Rhine-Westphalia',
+          'ISO3166-2-lvl4': 'DE-NW',
+          postcode: '53111',
+          country: 'Germany',
+          country_code: 'de'
+        }
+      }
+    ])
     // let fakeXhr;
     // let clock;
     // let requests = [];
@@ -133,6 +176,8 @@ describe('geocoder/Geocoder.vue', () => {
       });
       vm = comp.vm;
 
+      onQueryResultsSpy = sinon.replace(vm, 'onQueryResults', sinon.fake(vm.onQueryResults))
+      onQueryErrorSpy = sinon.replace(vm, 'onQueryError', sinon.fake(vm.onQueryError))
       // TODO: Sinon Fake XMLHttpRequest and Fake Timers did not work for us...
       // clock = sinon.useFakeTimers();
       // global.XMLHttpRequest = sinon.useFakeXMLHttpRequest();
@@ -203,7 +248,32 @@ describe('geocoder/Geocoder.vue', () => {
       });
     });
 
+    it('calls onQueryResults if fetch successful', done => {
+      sinon.replace(window, 'fetch', sinon.fake.resolves(new Response(fetchResults)))
+
+      vm.search = queryString;
+      vm.$nextTick(() => {
+        setTimeout(function () {
+          expect(onQueryResultsSpy).to.have.been.called;
+          done();
+        }, 50);
+      });
+    })
+
+    it('calls onQueryError if error during fetch', done => {
+      sinon.replace(window, 'fetch', sinon.fake.rejects())
+
+      vm.search = queryString;
+      vm.$nextTick(() => {
+        setTimeout(function () {
+          expect(onQueryErrorSpy).to.have.been.called;
+          done();
+        }, 50);
+      });
+    })
+
     afterEach(function () {
+      sinon.restore()
       // Like before we must clean up when tampering with globals.
       // global.XMLHttpRequest.restore();
       // clock.restore();

--- a/tests/unit/specs/components/geocoder/Geocoder.spec.js
+++ b/tests/unit/specs/components/geocoder/Geocoder.spec.js
@@ -202,14 +202,20 @@ describe('geocoder/Geocoder.vue', () => {
     });
 
     it('search watcher assigns last query string', done => {
+      sinon.replace(window, 'fetch', sinon.fake.resolves(new Response(fetchResults)))
+
       vm.search = queryString;
       vm.$nextTick(() => {
-        expect(vm.lastQueryStr === queryString).to.equal(true);
-        done();
+        setTimeout(function () {
+          expect(vm.lastQueryStr === queryString).to.equal(true);
+          done();
+        }, 50)
       });
     });
 
     it('search watcher query with results', done => {
+      sinon.replace(window, 'fetch', sinon.fake.resolves(new Response(fetchResults)))
+
       vm.search = queryString;
       vm.$nextTick(() => {
         expect(vm.lastQueryStr === queryString).to.equal(true);
@@ -227,7 +233,7 @@ describe('geocoder/Geocoder.vue', () => {
           expect(selectionItems === undefined).to.equal(false);
           expect(selectionItems.length === vm.results.length).to.equal(true);
           done();
-        }, 1800);
+        }, 50);
       });
     });
 


### PR DESCRIPTION
Here's some kind of follow-up to #343 where a flaky behaviour was observed during Geocoder unit tests.  
Sometimes a strange error was thrown : `TypeError: this.results.forEach is not a function`

This happened from the `query` function inside the `GeocoderController` called from the `Geocoder.vue` component where the actual request was made like this:

```JavaScript
try {
  const response = await json(ajax);
  return this.provider.handleResponse(response)
} catch (err) {
  return err
}
```

But with this code, if the underlying `fetch` was in error, the exception was caught then **returned** which made the `Promise` from the `Geocoder component` **resolve** instead of **reject**. So the error was considered as a result but was an `Error` instance instead of the expected `Array` of results...

This was simply corrected by removing the `try - catch`. If an error is thrown, it is practically caught inside the `querySelections` method of the `Geocoder component` as planned first.

The other unit tests for the `geocoder` have been slightly refactored to use a fake request instead of doing multiple API calls to `Nominatim`.  
Some could argue that there is still a test making a real request and that this shouldn't be done inside unit tests but as this is the one which unveiled the bug corrected in #343 I thought making a real request was valuable in this case.

Please note that this final implementation is perhaps not the best one (`onQueryError()` does nothing except making a call to `trace()`) but the bug is corrected and the component should behave as it was designed at first...