### PR TITLE
Upgrade Vuetify to version 2.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "proj4": "2.9.0",
         "vue": "2.7.14",
         "vue-i18n": "^8.28.2",
-        "vuetify": "2.6.15"
+        "vuetify": "2.7.1"
       },
       "devDependencies": {
         "@babel/core": "^7.12.16",
@@ -18085,8 +18085,9 @@
       "license": "MIT"
     },
     "node_modules/vuetify": {
-      "version": "2.6.15",
-      "license": "MIT",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.7.1.tgz",
+      "integrity": "sha512-DVFmRsDtYrITw9yuGLwpFWngFYzEgk0KwloDCIV3+vhZw+NBFJOSzdbttbYmOwtqvQlhDxUyIRQolrRbSFAKlg==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/johnleider"
@@ -30826,7 +30827,9 @@
       "dev": true
     },
     "vuetify": {
-      "version": "2.6.15",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.7.1.tgz",
+      "integrity": "sha512-DVFmRsDtYrITw9yuGLwpFWngFYzEgk0KwloDCIV3+vhZw+NBFJOSzdbttbYmOwtqvQlhDxUyIRQolrRbSFAKlg==",
       "requires": {}
     },
     "w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "proj4": "2.9.0",
     "vue": "2.7.14",
     "vue-i18n": "^8.28.2",
-    "vuetify": "2.6.15"
+    "vuetify": "2.7.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",


### PR DESCRIPTION
Upgrades Vuetify to latests stable LTS version 2.7.1. I tested the dev-setup and the production build. No problems so far, which could expected when looking at the Vuetify changelog https://github.com/vuetifyjs/vuetify/releases/tag/v2.7.0 and https://github.com/vuetifyjs/vuetify/releases/tag/v2.7.1.

Part of #330 