### PR TITLE
Allow custom 'publicPath' config

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ npm run lint:fix
 
 See [Configuration Reference](https://cli.vuejs.org/config/).
 
+### ENV VARs
+
+Besides the environment variables supported by Vue CLI Wegue offers the following ENV VARs:
+
+- `WGU_PUBLIC_PATH` allows to modify the [publicPath](https://cli.vuejs.org/config/#publicpath) Vue CLI configuration, which is used in the production build. Default of `publicPath` is `'./'`.
+
 ## Run with Docker
 
 Versioned Docker images are available on [DockerHub](https://hub.docker.com/r/meggsimum/wegue/tags).

--- a/docs/workshop.md
+++ b/docs/workshop.md
@@ -1004,3 +1004,16 @@ npm run build
 ```
 
 Now, you can move the contents of the `dist` directory to a web space and it can be seen online.
+
+### Modify deployment path (publicPath)
+
+In case you want to deploy your app somewhere else than at the root of a domain, e.g. in a sub-path like https://www.foobar.com/my-app/,
+you will need to specify that sub-path for the production build. This can be done by using the custom Wegue ENV VAR `WGU_PUBLIC_PATH`:
+
+```bash
+WGU_PUBLIC_PATH=/my-app/
+```
+
+For more information see [publicPath VUE CLI documentation](https://cli.vuejs.org/config/#publicpath).
+
+Note: The default of `publicPath` is `'./'`, which should work for a lot of common scenarios.

--- a/vue.config.js
+++ b/vue.config.js
@@ -6,6 +6,7 @@ const { defineConfig } = require('@vue/cli-service')
  */
 module.exports = defineConfig({
   assetsDir: 'static',
+  publicPath: process.env.WGU_PUBLIC_PATH || './',
   runtimeCompiler: true,
   pages: {
     app: {


### PR DESCRIPTION
This introduces an ENV VAR `WGU_PUBLIC_PATH` in order to change the `publicPath` Vue CLI configuration, which is used to create the production build, without modifying the Wegue code base.

Also changes the default for `publicPath` from `'/'` to `'./'`, since the relative notation `'./'` works for most cases, e.g. if the app is deployed at the root of a domain and for a deployment under a certain path. For any other special case use the  `WGU_PUBLIC_PATH` as stated above.

See https://cli.vuejs.org/config/#publicpath