### PR TITLE
Introduce global app language lookup

### DIFF
--- a/app-starter/WguAppTemplate.vue
+++ b/app-starter/WguAppTemplate.vue
@@ -120,6 +120,7 @@ export default {
     }
   },
   created () {
+    this.setGlobalAppLang(); // initially set global app language lookup
     this.setDocumentTitle();
   },
   mounted () {
@@ -180,17 +181,24 @@ export default {
       return moduleWins;
     },
     /**
-       * Sets the document title from language file.
-       */
+     * Sets the document title from language file.
+     */
     setDocumentTitle () {
       document.title = this.$t('app.browserTitle') || document.title;
+    },
+    /**
+     * Sets the current i18n language to the global app language lookup.
+     */
+    setGlobalAppLang () {
+      Vue.prototype.appLanguage = this.$i18n.locale;
     }
   },
   watch: {
     /**
-       * Watch for locale changes.
-       */
+     * Watch for locale changes.
+     */
     '$i18n.locale': function () {
+      this.setGlobalAppLang();
       this.setDocumentTitle();
     }
   }

--- a/app-starter/WguAppTemplate.vue
+++ b/app-starter/WguAppTemplate.vue
@@ -190,7 +190,7 @@ export default {
      * Sets the current i18n language to the global app language lookup.
      */
     setGlobalAppLang () {
-      Vue.prototype.appLanguage = this.$i18n.locale;
+      Vue.prototype.$appLanguage = this.$i18n.locale;
     }
   },
   watch: {

--- a/tests/unit/specs/WguAppTemplate.spec.js
+++ b/tests/unit/specs/WguAppTemplate.spec.js
@@ -89,5 +89,26 @@ describe('WguAppTpl.vue', () => {
       expect(moduleData[0].type).to.equal('wgu-infoclick-win');
       expect(moduleData[0].target).to.equal('menu');
     });
+
+    it('has a method setGlobalAppLang', () => {
+      expect(vm.setGlobalAppLang).to.be.a('function');
+    });
+  });
+
+  describe('global app language lookup', () => {
+    let comp;
+    let vm;
+    beforeEach(() => {
+      comp = shallowMount(WguAppTpl);
+      vm = comp.vm;
+    });
+
+    it('is set correctly', () => {
+      expect(vm.$i18n.locale).to.equal(Vue.prototype.appLanguage);
+    });
+
+    afterEach(() => {
+      comp.destroy();
+    });
   });
 });

--- a/tests/unit/specs/WguAppTemplate.spec.js
+++ b/tests/unit/specs/WguAppTemplate.spec.js
@@ -104,7 +104,7 @@ describe('WguAppTpl.vue', () => {
     });
 
     it('is set correctly', () => {
-      expect(vm.$i18n.locale).to.equal(Vue.prototype.appLanguage);
+      expect(vm.$i18n.locale).to.equal(Vue.prototype.$appLanguage);
     });
 
     afterEach(() => {


### PR DESCRIPTION
This PR introduces a global application language lookup `Vue.prototype.appLanguage`, which allows to access the current language in a static manner from normal JS-/ES- resources, without being in a Vue component.