### PR TITLE
Fix toQueryString function in UrlUtil for null values

### DIFF
--- a/src/util/Url.js
+++ b/src/util/Url.js
@@ -100,11 +100,13 @@ const UrlUtil = {
   toQueryString (obj) {
     return Object.keys(obj)
       .reduce((a, k) => {
-        a.push(
-          typeof obj[k] === 'object'
-            ? this.toQueryString(obj[k])
-            : `${encodeURIComponent(k)}=${encodeURIComponent(obj[k])}`
-        );
+        if (obj[k] !== null) {
+          a.push(
+            (typeof obj[k] === 'object')
+              ? this.toQueryString(obj[k])
+              : `${encodeURIComponent(k)}=${encodeURIComponent(obj[k])}`
+          );
+        }
         return a;
       }, [])
       .join('&');

--- a/tests/unit/specs/util/Url.spec.js
+++ b/tests/unit/specs/util/Url.spec.js
@@ -39,4 +39,19 @@ describe('UrlUtil', () => {
     const paramVal = UrlUtil.getQueryParam('foo');
     expect(paramVal).to.equal(undefined);
   });
+
+  it('toQueryString returns correct query string', () => {
+    const params = {
+      foo: 'bar',
+      kalle: 0,
+      ralle: 8.88,
+      bully: true,
+      nullinger: null,
+      obj: {
+        sub1: 1
+      }
+    };
+    const queryString = UrlUtil.toQueryString(params);
+    expect(queryString).to.eql('foo=bar&kalle=0&ralle=8.88&bully=true&sub1=1');
+  });
 });


### PR DESCRIPTION
This PR fixes the `toQueryString` function in the `UrlUtil` in case a `null` value is passed in for a parameter. Main reason is that `typeof null` resolves to `'object'` (thanks JavaScript :roll_eyes: ), which leads to a recursion with null instead of an object.