### PR TITLE
Forward layer reference to map overlays

### DIFF
--- a/docs/reusable-components.md
+++ b/docs/reusable-components.md
@@ -35,6 +35,7 @@ An Overlay can either be statically positioned or can be used to implement a too
 ```javascript
 { 
   feature:  ol/Feature,
+  layer: ol/Layer,
   hoverAttribute: string
 }
 ```
@@ -70,7 +71,7 @@ export default {
 
 #### Feature hover tooltip
 
-The following example implements a customized tooltip to render an attribute of a feature, when it is hovered on the map. Again, the default slot of `<wgu-map-overlay>` is filled by a `<v-sheet>`. A data object containing the `feature` and optionally `hoverAttribute` properties is available from the slot-scope. Declare the following vue template and add it to you `WguAppTemplate`:
+The following example implements a customized tooltip to render an attribute of a feature, when it is hovered on the map. Again, the default slot of `<wgu-map-overlay>` is filled by a `<v-sheet>`. A data object containing the `feature`, `layer` and optionally `hoverAttribute` properties is available from the slot-scope. Declare the following vue template and add it to you `WguAppTemplate`:
 
 ```javascript
 <template>

--- a/src/components/ol/HoverController.js
+++ b/src/components/ol/HoverController.js
@@ -1,14 +1,14 @@
 import TileWmsSource from 'ol/source/TileWMS';
 import ImageWMSSource from 'ol/source/ImageWMS';
 import VectorSource from 'ol/source/Vector';
-import VectorTileSource from 'ol/source/VectorTile'
+import VectorTileSource from 'ol/source/VectorTile';
 import WMSGetFeatureInfo from 'ol/format/WMSGetFeatureInfo';
-import { WguEventBus } from '../../WguEventBus'
+import { WguEventBus } from '../../WguEventBus';
 import axios from 'axios';
 
 export default class HoverController {
   DEFAULT_POINTER_REST_INTERVAL = 150;
-  DEFAULT_HOVER_OVERLAY = 'wgu-hover-tooltip'
+  DEFAULT_HOVER_OVERLAY = 'wgu-hover-tooltip';
 
   map = null;
   timerHandle = null;
@@ -101,7 +101,7 @@ export default class HoverController {
             featureInfos.push(...features.map((feat) => {
               return { layer, feature: feat };
             }));
-            me.displayTooltip(featureInfos, coordinate)
+            me.displayTooltip(featureInfos, coordinate);
           })
           .catch(function (error) {
             if (!axios.isCancel(error)) {
@@ -114,7 +114,7 @@ export default class HoverController {
         featureInfos.push(...features.map((feat) => {
           return { layer, feature: feat };
         }));
-        me.displayTooltip(featureInfos, coordinate)
+        me.displayTooltip(featureInfos, coordinate);
       }
     });
 
@@ -206,6 +206,7 @@ export default class HoverController {
     };
     WguEventBus.$emit(overlayId + '-update-overlay', true, coordinate, {
       feature,
+      layer,
       hoverAttribute: hoverAttr
     });
     me.activeOverlayId = overlayId;

--- a/tests/unit/specs/components/ol/HoverController.spec.js
+++ b/tests/unit/specs/components/ol/HoverController.spec.js
@@ -72,6 +72,7 @@ describe('ol/HoverController.js', () => {
         expect(visible).to.equal(true);
         expect(position).to.equal(undefined);
         expect(data.feature).to.equal(feat);
+        expect(data.layer).to.equal(layer);
         expect(data.hoverAttribute).to.equal('foo');
         done();
       });


### PR DESCRIPTION
A very small one-liner here following answer to #358, this simply gives the possibility to access the layer inside which the hovered feature is present.

As this new property can be destructured when needed, it shouldn't impact existing code...