### PR TITLE
Changed deprecated syntax in .eslintrc test file

### DIFF
--- a/tests/unit/.eslintrc
+++ b/tests/unit/.eslintrc
@@ -3,8 +3,8 @@
     "mocha": true
   },
   "globals": {
-    "expect": true,
-    "sinon": true
+    "expect": "readonly",
+    "sinon": "readonly"
   },
   "rules": {
     "no-unused-expressions": "off"


### PR DESCRIPTION
This simple PR corrects the content of the `.eslintrc` file which is used while generating unit test builds.

The `globals` definition there was still using [an older deprecated syntax](https://eslint.org/docs/latest/use/configure/language-options#using-configuration-files-1).