### PR TITLE
Enable Vuetify treeshaking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,8 @@
         "sinon": "^9.2.4",
         "sinon-chai": "^3.5.0",
         "vue-cli-plugin-vuetify": "~2.5.8",
-        "vue-template-compiler": "2.7.14"
+        "vue-template-compiler": "2.7.14",
+        "vuetify-loader": "^1.9.2"
       },
       "engines": {
         "node": ">= 16.19.0",
@@ -5341,6 +5342,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "dev": true,
@@ -6591,6 +6601,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decache": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/decache/-/decache-4.6.2.tgz",
+      "integrity": "sha512-2LPqkLeu8XWHU8qNCS3kcF6sCcb5zIzvWaAHYSvPfwhdd7mHuah29NssMzrTYyHN4F5oFy2ko9OBYxegtU0FEw==",
+      "dev": true,
+      "dependencies": {
+        "callsite": "^1.0.0"
       }
     },
     "node_modules/decamelize": {
@@ -8990,6 +9009,58 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/file-loader": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
+      "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
+      "dev": true,
+      "dependencies": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/file-loader/node_modules/loader-utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "dev": true,
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "node_modules/file-loader/node_modules/schema-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/file-type": {
@@ -18431,6 +18502,52 @@
         "vue": "^2.6.4"
       }
     },
+    "node_modules/vuetify-loader": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/vuetify-loader/-/vuetify-loader-1.9.2.tgz",
+      "integrity": "sha512-8PP2w7aAs/rjA+Izec6qY7sHVb75MNrGQrDOTZJ5IEnvl+NiFhVpU2iWdRDZ3eMS842cWxSWStvkr+KJJKy+Iw==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.2.0",
+        "decache": "^4.6.0",
+        "file-loader": "^6.2.0",
+        "loader-utils": "^2.0.0"
+      },
+      "peerDependencies": {
+        "gm": "^1.23.0",
+        "pug": "^2.0.0 || ^3.0.0",
+        "sharp": "*",
+        "vue": "^2.7.2",
+        "vuetify": "^1.3.0 || ^2.0.0",
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "gm": {
+          "optional": true
+        },
+        "pug": {
+          "optional": true
+        },
+        "sharp": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vuetify-loader/node_modules/loader-utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "dev": true,
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
       "dev": true,
@@ -22966,6 +23083,12 @@
         "get-intrinsic": "^1.0.2"
       }
     },
+    "callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
+      "dev": true
+    },
     "callsites": {
       "version": "3.1.0",
       "dev": true
@@ -23755,6 +23878,15 @@
       "dev": true,
       "requires": {
         "ms": "2.1.2"
+      }
+    },
+    "decache": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/decache/-/decache-4.6.2.tgz",
+      "integrity": "sha512-2LPqkLeu8XWHU8qNCS3kcF6sCcb5zIzvWaAHYSvPfwhdd7mHuah29NssMzrTYyHN4F5oFy2ko9OBYxegtU0FEw==",
+      "dev": true,
+      "requires": {
+        "callsite": "^1.0.0"
       }
     },
     "decamelize": {
@@ -25370,6 +25502,40 @@
     },
     "file-extension": {
       "version": "4.0.5"
+    },
+    "file-loader": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
+      "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "schema-utils": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+          "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
     },
     "file-type": {
       "version": "8.1.0",
@@ -31475,6 +31641,32 @@
       "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.7.1.tgz",
       "integrity": "sha512-DVFmRsDtYrITw9yuGLwpFWngFYzEgk0KwloDCIV3+vhZw+NBFJOSzdbttbYmOwtqvQlhDxUyIRQolrRbSFAKlg==",
       "requires": {}
+    },
+    "vuetify-loader": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/vuetify-loader/-/vuetify-loader-1.9.2.tgz",
+      "integrity": "sha512-8PP2w7aAs/rjA+Izec6qY7sHVb75MNrGQrDOTZJ5IEnvl+NiFhVpU2iWdRDZ3eMS842cWxSWStvkr+KJJKy+Iw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.2.0",
+        "decache": "^4.6.0",
+        "file-loader": "^6.2.0",
+        "loader-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        }
+      }
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "sinon": "^9.2.4",
     "sinon-chai": "^3.5.0",
     "vue-cli-plugin-vuetify": "~2.5.8",
-    "vue-template-compiler": "2.7.14"
+    "vue-template-compiler": "2.7.14",
+    "vuetify-loader": "^1.9.2"
   },
   "engines": {
     "node": ">= 16.19.0",

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 // The Vue build version to load with the `import` command
 // (runtime-only or standalone) has been set in vue.config.js with runtimeCompiler.
 import Vue from 'vue';
-import Vuetify from 'vuetify';
+import Vuetify from 'vuetify/lib/framework';
 import PortalVue from 'portal-vue'
 import VueI18n from 'vue-i18n';
 import 'roboto-fontface/css/roboto/roboto-fontface.css'
@@ -13,7 +13,6 @@ import UrlUtil from './util/Url';
 import LocaleUtil from './util/Locale';
 import ObjectUtil from './util/Object';
 import ColorThemeUtil from './util/ColorTheme'
-import 'vuetify/dist/vuetify.min.css';
 import axios from 'axios';
 
 Vue.use(Vuetify);

--- a/vue.config.js
+++ b/vue.config.js
@@ -57,10 +57,12 @@ module.exports = defineConfig({
     // Tweak configuration options for Karma test runner to produce a bundle
     // which can run under Chrome headless. Avoid warnings due to custom entries
     // and customized filenames. Enable correct code coverage of .vue files.
+    // Disable Vuetify treeshaking.
     if (process.env.NODE_ENV === 'test') {
       config.devtool = 'eval'
       config.optimization.runtimeChunk = false
       config.optimization.splitChunks = false
+      config.plugins = config.plugins.filter(plugin => plugin.constructor.name !== 'VuetifyLoaderPlugin')
       delete config.target
       delete config.entry
       delete config.output.filename


### PR DESCRIPTION
This PR is a proposal to enable [Vuetify treeshaking](https://v2.vuetifyjs.com/en/features/treeshaking/#treeshaking).

This simple tweak reduces the total size of the `dist` directory of `Wegue starter app` from 18.1MB to 14.5MB.

Some technical difficulties are encountered with unit tests though once the `Vuetify loader` is installed. Please note that this issue also happens on a fresh app scaffolded with `Vue-CLI`. The way they get around this when generating an app from scratch is to put `vuetify` in the `transpileDependencies` list, which is currently empty in `Wegue` by default.  
This transpile operation makes the bundle size to grow of 26.374 bytes with the starter app which is negligible, but also produces a warning: `[BABEL] Note: The code generator has deoptimised the styling of C:\Sources\Wegue\node_modules\vuetify\dist\vuetify.js as it exceeds the max of 500KB.`

The only other way around I've found is to disable treeshaking once `NODE_ENV === 'test'` inside `vue.config.js`. I haven't encountered problems in my personal applications with this yet but this should be tested on more apps I think...

So this PR implements the second solution (disabling treeshaking during unit tests) but in case you'd like to test the other option, all what should be done is commenting out line 65 in `vue.config.js` and replacing line 75 of the same file by

```js
  transpileDependencies: ['vuetify']
```

Just tell me whether treeshaking would be of an interest and what you think about this,

Cheers
Sébastien