### PR TITLE
Global feature hover options

### DIFF
--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -19,6 +19,7 @@ This describes the Wegue application configuration, which is modelled as JSON do
 | **mapCenter**      | Initial center of the map in map projection | `"mapCenter": [0, 0]` |
 | mapProjection      | Configuration object for CRS / projection used for the map | see [mapProjection](wegue-configuration?id=mapprojection) |
 | mapGeodataDragDop  | Configuration object for geodata file drag/drop functionality on the map. Only by setting the config this function will be enabled. | see [mapGeodataDragDop](wegue-configuration?id=mapGeodataDragDop) |
+| mapHover           | Configuration object to customize the bevahior of hover tooltips on the map. | see [mapHover](wegue-configuration?id=mapHover)
 | **modules**        | Array of module configuration objects | See [modules](module-configuration) |
 | **mapLayers**      | Array of map layer configuration objects | See [mapLayers](map-layer-configuration) |
 | overviewMap        | Configuration object for the overview map. | See [overviewMap](wegue-configuration?id=overviewMap)
@@ -225,6 +226,29 @@ Below is an example for such a configuration object:
       "displayInLayerList": true
     }
 ```
+
+### mapHover
+
+Optional configuration object to customize the behavior of hover tooltips on the map. 
+The following properties are supported:
+
+| Property           | Meaning   | Example |
+|--------------------|:---------:|---------|
+| delay              | Timespan in milliseconds, by which displaying the tooltip is deferred after the mouse pointer rests. Defaults to `150`. | `"delay": 150`
+| hideOnMousemove    | Hide the tooltip when the mouse cursor is moved. Defaults to `false`. | `"hideOnMousemove": false`
+| hoverOverlay       | ID of a custom map overlay to use as a default display when a feature of the layer is hovered. Declaration of the `hoverOverlay` property on a mapLayer level takes precedence. For more information on how to implement a map overlay see the [reusable components](reusable-components?id=map-overlay) section. Defaults to Wegue's default tooltip `wgu-hover-tooltip` |  `"hoverOverlay": "my-custom-overlay"`
+
+Example:
+
+```json
+"mapHover":
+    {
+      "delay": 150,
+      "hideOnMousemove": false,
+      "hoverOverlay": "my-custom-overlay"
+    }
+```
+
 
 ### lang
 

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -19,7 +19,7 @@ This describes the Wegue application configuration, which is modelled as JSON do
 | **mapCenter**      | Initial center of the map in map projection | `"mapCenter": [0, 0]` |
 | mapProjection      | Configuration object for CRS / projection used for the map | see [mapProjection](wegue-configuration?id=mapprojection) |
 | mapGeodataDragDop  | Configuration object for geodata file drag/drop functionality on the map. Only by setting the config this function will be enabled. | see [mapGeodataDragDop](wegue-configuration?id=mapGeodataDragDop) |
-| mapHover           | Configuration object to customize the bevahior of hover tooltips on the map. | see [mapHover](wegue-configuration?id=mapHover)
+| mapHover           | Configuration object containing application wide parameters for hover tooltips on the map. | see [mapHover](wegue-configuration?id=mapHover)
 | **modules**        | Array of module configuration objects | See [modules](module-configuration) |
 | **mapLayers**      | Array of map layer configuration objects | See [mapLayers](map-layer-configuration) |
 | overviewMap        | Configuration object for the overview map. | See [overviewMap](wegue-configuration?id=overviewMap)
@@ -229,14 +229,14 @@ Below is an example for such a configuration object:
 
 ### mapHover
 
-Optional configuration object to customize the behavior of hover tooltips on the map. 
+Wegue allows for customized tooltips that display one or multiple attributes of a feature when it is hovered over on the map. The optional `mapHover` property in the main Wegue configuration specifies application-wide parameters for tooltip behavior. This property affects only layers with the `hoverable` attribute set to `true` - refer to the [mapLayers](map-layer-configuration) section for more details.
 The following properties are supported:
 
 | Property           | Meaning   | Example |
 |--------------------|:---------:|---------|
 | delay              | Timespan in milliseconds, by which displaying the tooltip is deferred after the mouse pointer rests. Defaults to `150`. | `"delay": 150`
 | hideOnMousemove    | Hide the tooltip when the mouse cursor is moved. Defaults to `false`. | `"hideOnMousemove": false`
-| hoverOverlay       | ID of a custom map overlay to use as a default display when a feature of the layer is hovered. Declaration of the `hoverOverlay` property on a mapLayer level takes precedence. For more information on how to implement a map overlay see the [reusable components](reusable-components?id=map-overlay) section. Defaults to Wegue's default tooltip `wgu-hover-tooltip` |  `"hoverOverlay": "my-custom-overlay"`
+| hoverOverlay       | ID of a custom map overlay to use as a default display when a feature of a layer is hovered. Declaration of the `hoverOverlay` property on a mapLayer level takes precedence. For more information on how to implement a map overlay see the [reusable components](reusable-components?id=map-overlay) section. Defaults to Wegue's default tooltip `wgu-hover-tooltip` |  `"hoverOverlay": "my-custom-overlay"`
 
 Example:
 

--- a/src/components/ol/HoverController.js
+++ b/src/components/ol/HoverController.js
@@ -40,6 +40,15 @@ export default class HoverController {
         me.onPointerRest(event);
       }, timeout);
     });
+
+    // If the mouse leaves the map canvas, clear out the "pointer rest" timer and hide
+    // the existing tooltip.
+    map.getViewport().addEventListener('mouseout', (event) => {
+      if (me.timerHandle) {
+        clearTimeout(me.timerHandle);
+      }
+      me.displayTooltip(null);
+    }, false);
   }
 
   /**

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -251,7 +251,7 @@ export default {
      * @return {HoverController} HoverController instance.
      */
     createHoverController () {
-      return new HoverController(this.map);
+      return new HoverController(this.map, this.$appConfig.mapHover);
     },
 
     /**

--- a/tests/unit/specs/components/ol/HoverController.spec.js
+++ b/tests/unit/specs/components/ol/HoverController.spec.js
@@ -43,6 +43,9 @@ describe('ol/HoverController.js', () => {
       expect(comp.timerHandle).to.equal(null);
       expect(comp.activeOverlayId).to.equal(null);
       expect(comp.pendingRequestsCancelSrc).to.equal(null);
+      expect(comp.conf.delay).to.equal(150)
+      expect(comp.conf.hideOnMousemove).to.equal(false)
+      expect(comp.conf.hoverOverlay).to.equal('wgu-hover-tooltip')
     });
 
     afterEach(() => {


### PR DESCRIPTION
This draft adds a top level option `mapHover` to app.conf, to provide application wide defaults for feature hover customization. The following properties are supported (quoted from the doc):

| Property           | Meaning   | Example |
|--------------------|:---------:|---------|
| delay              | Timespan in milliseconds, by which displaying the tooltip is deferred after the mouse pointer rests. Defaults to `150`. | `"delay": 150`
| hideOnMousemove    | Hide the tooltip when the mouse cursor is moved. Defaults to `false`. | `"hideOnMousemove": false`
| hoverOverlay       | ID of a custom map overlay to use as a default display when a feature of the layer is hovered. Declaration of the `hoverOverlay` property on a mapLayer level takes precedence. For more information on how to implement a map overlay see the [reusable components](reusable-components?id=map-overlay) section. Defaults to Wegue's default tooltip `wgu-hover-tooltip` |  `"hoverOverlay": "my-custom-overlay"`

Example:

```json
"mapHover":
    {
      "delay": 150,
      "hideOnMousemove": false,
      "hoverOverlay": "my-custom-overlay"
    }
```


Additionally, some problems related to dangling tooltips have been fixed when the mouse cursor leaves the map canvas (efacbde3d8a6a2c04c5ae466232f235c4ac37ef7).