### PR TITLE
wfs endpoint with param fix

### DIFF
--- a/src/factory/Layer.js
+++ b/src/factory/Layer.js
@@ -199,7 +199,8 @@ export const LayerFactory = {
       format: new this.formatMapping[lConf.format](lConf.formatConfig),
       loader: (extent) => {
         // assemble WFS GetFeature request
-        let wfsRequest = lConf.url + '?service=WFS&' +
+        const pre = lConf.url.includes("?") ? "&" : "?"
+        let wfsRequest = lConf.url + pre + 'service=WFS&' +
           'version=' + lConf.version + '&request=GetFeature&' +
           'typename=' + lConf.typeName + '&' +
           'outputFormat=' + outputFormat + '&srsname=' + lConf.projection;


### PR DESCRIPTION
Hi, this PR fixes an issue in WFS URL formatting that prevent connection to wfs endpoints urls that already contain parameters, like qgis server connections: [http://qgisserver?MAP=/path/to/project&](http://qgisserver/?MAP=/path/to/project&)