### PR TITLE
Explicitly call 'npm run lint' in CI test pipeline

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -14,4 +14,5 @@ jobs:
 
       - run: npm ci
       - run: npm run init:app
+      - run: npm run lint
       - run: npm run test


### PR DESCRIPTION
This starts the linting process (`npm run lint`) explicitly in the CI test pipeline because the implicit lint call in the `npm run test` command does not break the pipeline, even if there are linting errors. So possible linting errors land in the Wegue code base if not discovered by human reviewers, which leads to a broken build.