### PR TITLE
Add CSS classes to Wegue toolbar buttons

### DIFF
--- a/app-starter/components/AppHeader.vue
+++ b/app-starter/components/AppHeader.vue
@@ -35,6 +35,7 @@
       <template v-slot:activator="{on}">
 
       <v-btn icon v-on="on"
+        class="wgu-menu-button"
         color="onprimary"
         :title="$t('wgu-toolbar-menu.title')">
         <v-icon medium>menu</v-icon>

--- a/src/components/geolocator/Geolocator.vue
+++ b/src/components/geolocator/Geolocator.vue
@@ -1,6 +1,7 @@
 <template>
 <span>
    <v-btn @click="geolocateUserAndShowMarkerOnMap" icon
+      class="wgu-action-button"
       color="onprimary"
       :title="$t('wgu-geolocator.title')">
       <v-icon v-if='this.isSearchingForGeolocation'>update</v-icon>

--- a/src/components/localeswitcher/LocaleSwitcher.vue
+++ b/src/components/localeswitcher/LocaleSwitcher.vue
@@ -9,7 +9,7 @@
           color="onprimary"
           background-color="transparent"
           :title="$t('wgu-localeswitcher.title')"
-          class="ma-2"
+          class="ma-2 wgu-menu-button"
           icon
           v-on="on"
           v-bind="attrs"

--- a/src/components/maxextentbutton/ZoomToMaxExtentButton.vue
+++ b/src/components/maxextentbutton/ZoomToMaxExtentButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-btn icon color="onprimary" @click="onClick"
+  <v-btn icon color="onprimary" @click="onClick" class="wgu-action-button"
     :title="$t('wgu-zoomtomaxextent.title')">
     <v-icon medium>{{icon}}</v-icon>
   </v-btn>

--- a/src/components/modulecore/ToggleButton.vue
+++ b/src/components/modulecore/ToggleButton.vue
@@ -4,6 +4,7 @@
     dense
     color="onprimary"
     background-color="transparent"
+    class="wgu-toggle-button"
     :title="$t(moduleName + '.title')"
     v-model="show">
     <v-btn icon :value="true" color="onprimary" @click="toggleUi">


### PR DESCRIPTION
Adds CSS classes 

- `wgu-toggle-button` 
-  `wgu-geolocator-btn`
-  `wgu-localeswitcher-btn`
- `wgu-zoomtomaxextent-btn`

to module related buttons in order to easily style the automatically created Wegue module activator buttons (analogous to `wgu-map-button`).