### PR TITLE
Allow switching base layer by keyboard (ENTER)

### DIFF
--- a/src/components/bglayerswitcher/BgLayerList.vue
+++ b/src/components/bglayerswitcher/BgLayerList.vue
@@ -22,6 +22,7 @@
             'onsecondary--text': active
           }"
           @click="toggle"
+          @keyup.enter="toggle"
         >
           <wgu-layerpreviewimage
             :layer="layer"


### PR DESCRIPTION
This enables the switch of the map's base layer in the `BgLayerSwitcher` component by hitting the ENTER key instead of clicking only.