### PR TITLE
Refactor VueI18n creation to own module

### DIFF
--- a/src/locales/wgu-i18n.js
+++ b/src/locales/wgu-i18n.js
@@ -1,0 +1,18 @@
+/**
+ * Creates the VueI18n object used for internationalization.
+ */
+import Vue from 'vue';
+import VueI18n from 'vue-i18n';
+import LocaleUtil from '@/util/Locale';
+
+Vue.use(VueI18n);
+
+const appConfig = Vue.prototype.$appConfig;
+
+const preset = {
+  locale: LocaleUtil.getPreferredLanguage(appConfig),
+  fallbackLocale: LocaleUtil.getFallbackLanguage(appConfig),
+  messages: LocaleUtil.importVueI18nLocales()
+};
+
+export const i18n = new VueI18n(preset);

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,6 @@
 import Vue from 'vue';
 import Vuetify from 'vuetify/lib/framework';
 import PortalVue from 'portal-vue'
-import VueI18n from 'vue-i18n';
 import 'roboto-fontface/css/roboto/roboto-fontface.css'
 import '@mdi/font/css/materialdesignicons.css'
 import 'material-icons/iconfont/material-icons.css'
@@ -17,7 +16,6 @@ import axios from 'axios';
 
 Vue.use(Vuetify);
 Vue.use(PortalVue);
-Vue.use(VueI18n);
 
 require('./assets/css/wegue.css');
 
@@ -60,21 +58,6 @@ const createVuetify = function (appConfig) {
     }
   };
   return new Vuetify(preset);
-}
-
-/**
- * Creates the VueI18n object used for internationalization.
- *
- * @param {Object} appConfig Global application context.
- * @returns The active I18n instance.
- */
-const createVueI18n = function (appConfig) {
-  const preset = {
-    locale: LocaleUtil.getPreferredLanguage(appConfig),
-    fallbackLocale: LocaleUtil.getFallbackLanguage(appConfig),
-    messages: LocaleUtil.importVueI18nLocales()
-  };
-  return new VueI18n(preset);
 }
 
 /**
@@ -181,13 +164,17 @@ const migrateAppConfig = function (appConfig) {
  *
  * @param {Object} appConfig Global application context.
  */
-const createApp = function (appConfig) {
+const createApp = async function (appConfig) {
   // make app config accessible for all components
   Vue.prototype.$appConfig = migrateAppConfig(appConfig);
 
+  // dynamic import, otherwise Vue.prototype.$appConfig won't be set yet on
+  // static import
+  const { i18n } = await import('./locales/wgu-i18n.js');
+
   new Vue({
     vuetify: createVuetify(appConfig),
-    i18n: createVueI18n(appConfig),
+    i18n,
     render: h => h(WguApp)
   }).$mount('#app');
 };

--- a/tests/unit/specs/util/Locale.spec.js
+++ b/tests/unit/specs/util/Locale.spec.js
@@ -1,4 +1,5 @@
 import LocaleUtil from '@/util/Locale'
+import Vue from 'vue';
 
 const appConfig = {
   lang: {
@@ -10,6 +11,8 @@ const appConfig = {
     fallback: 'de'
   }
 };
+
+Vue.prototype.$appConfig = appConfig;
 
 describe('LocaleUtil', () => {
   it('is defined', () => {


### PR DESCRIPTION
This refactors the creation of the `VueI18n` instance by encapsulating it in an own ES module. So the i18n instance can be imported to other pure ES modules and will allow internationalization there.

This follows the approach given here: https://github.com/kazupon/vue-i18n/issues/149#issuecomment-357455921

This would make the introduction of a global `$appLanguage` variable in #356  obsolete by this much cleaner and more versatile approach. If you approve this PR, I'd happily revert #356 afterwards in a separate PR.

Accessing the current app language in pure ES modules could then be done by the following code:

```js
const { i18n } = await import('../../../src/locales/wgu-i18n.js');
console.log(i18n.locale);
```

