### PR TITLE
Fix hoverable WMS layers.

### DIFF
--- a/src/factory/Layer.js
+++ b/src/factory/Layer.js
@@ -129,11 +129,11 @@ export const LayerFactory = {
         ratio: lConf.ratio,
         interpolate: lConf.interpolate,
         projection: lConf.projection,
-        crossOrigin: lConf.crossOrigin,
-        hoverable: lConf.hoverable,
-        hoverAttribute: lConf.hoverAttribute,
-        hoverOverlay: lConf.hoverOverlay
-      })
+        crossOrigin: lConf.crossOrigin
+      }),
+      hoverable: lConf.hoverable,
+      hoverAttribute: lConf.hoverAttribute,
+      hoverOverlay: lConf.hoverOverlay
     });
 
     return layer;
@@ -158,11 +158,11 @@ export const LayerFactory = {
         serverType: lConf.serverType,
         tileGrid: lConf.tileGrid,
         projection: lConf.projection,
-        crossOrigin: lConf.crossOrigin,
-        hoverable: lConf.hoverable,
-        hoverAttribute: lConf.hoverAttribute,
-        hoverOverlay: lConf.hoverOverlay
-      })
+        crossOrigin: lConf.crossOrigin
+      }),
+      hoverable: lConf.hoverable,
+      hoverAttribute: lConf.hoverAttribute,
+      hoverOverlay: lConf.hoverOverlay
     });
 
     return layer;


### PR DESCRIPTION
Hoverable WMS layers didn`t work because the respective properties were accidently forwarded to the source instead of the layer. It seems that this bug has been around ever since the first implementation.