### PR TITLE
Unregister ResizeObserver for map container

### DIFF
--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -78,6 +78,7 @@ export default {
         me.map.updateSize();
       });
       resizeObserver.observe(container);
+      this.resizeObserver = resizeObserver;
 
       // add tabIndex attribute to the map's container, so it gets focusable.
       // Otherwise the OL keyboard navigation won't work, see keyboardEventTarget
@@ -98,6 +99,11 @@ export default {
     }, 200);
   },
   destroyed () {
+    // unregister resizing of the map
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+    }
+
     // Send the event 'ol-map-unmounted' with the OL map as payload
     WguEventBus.$emit('ol-map-unmounted', this.map);
 


### PR DESCRIPTION
This unregisters the `ResizeObserver` for the map's container element, when the map is unmounted/destroyed.

Besides having a better cleanup this also removes the null pointer access within the `ResizeObserver` handler in the hot-reload of the dev- setup, when then `WguApp.vue` is changed. 