### PR TITLE
Avoid dist directory cluttering when running unit tests

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -58,14 +58,25 @@ module.exports = defineConfig({
     // which can run under Chrome headless. Avoid warnings due to custom entries
     // and customized filenames. Enable correct code coverage of .vue files.
     // Disable Vuetify treeshaking.
+    // Ensure build is sent to a temporary directory and keep only necessary plugins.
     if (process.env.NODE_ENV === 'test') {
+      const PLUGINS_TO_KEEEP = [
+        'VueLoaderPlugin',
+        'DefinePlugin',
+        'CaseSensitivePathsPlugin',
+        'FriendlyErrorsWebpackPlugin'
+      ]
+
       config.devtool = 'eval'
       config.optimization.runtimeChunk = false
       config.optimization.splitChunks = false
-      config.plugins = config.plugins.filter(plugin => plugin.constructor.name !== 'VuetifyLoaderPlugin')
+      config.plugins = config.plugins.filter(plugin =>
+        PLUGINS_TO_KEEEP.includes(plugin.constructor.name)
+      )
       delete config.target
       delete config.entry
       delete config.output.filename
+      delete config.output.path
     }
   },
 


### PR DESCRIPTION
This PR changes the configuration in `vue.config.js` when in test mode to avoid an unsuitable behaviour introduced, apparently, when updating to Vue-CLI 3...

For now, when you run the unit tests, `karma-webpack` outputs the results in the `dist` directory, potentially destroying your latest build and adding some files only related to tests (common.js and runtime.js).

The reason is that when Vue-CLI 2 was used, `Karma` was one of the test runners recommended by Vue, so configuration was adapted for it. If you go back in time, you'll see that webpack configuration was almost empty in [test mode](https://github.com/wegue-oss/wegue/blob/v1.2.1/build/webpack.test.conf.js) compared to [dev mode](https://github.com/wegue-oss/wegue/blob/v1.2.1/build/webpack.dev.conf.js).  
In Vue-CLI, the recommended test runner was `mochapack` which works completely differently. But most important, as stated in their documentation, it is written in a way that nothing is ever written on the disk by `webpack`, [all stays is memory](https://github.com/sysgears/mochapack/blob/38012769f63cc4666b1f4df476162fee66acfc85/src/webpack/compiler/registerInMemoryCompiler.ts#L12:L82).

So there are two tweaks made by this PR in the config file:

1. Remove the unneeded plugins from webpack configuration in order to behave closer to like it was in Vue-CLI 2
2. Remove the config.output.path so [default value of `karma-webpack` is taken](https://www.npmjs.com/package/karma-webpack#default-webpack-configuration), effectively outputting the build inside a temporary directory