### PR TITLE
Remove non-effective color prop in ToggleButton

### DIFF
--- a/src/components/modulecore/ToggleButton.vue
+++ b/src/components/modulecore/ToggleButton.vue
@@ -7,7 +7,7 @@
     class="wgu-toggle-button"
     :title="$t(moduleName + '.title')"
     v-model="show">
-    <v-btn icon :value="true" color="onprimary" @click="toggleUi">
+    <v-btn icon :value="true" @click="toggleUi">
       <v-icon color="onprimary" medium>{{icon}}</v-icon>
     </v-btn>
   </v-btn-toggle>


### PR DESCRIPTION
This removes non-effective color prop definition in the `ToggleButton` component.