### PR TITLE
Fix PDOK service URLs in 'projected' example

### DIFF
--- a/app-starter/static/app-conf-projected.json
+++ b/app-starter/static/app-conf-projected.json
@@ -77,7 +77,7 @@
     {
       "type": "WFS",
       "lid": "dutch-nat-parks",
-      "url": "https://geodata.nationaalgeoregister.nl/nationaleparken/wfs",
+      "url": "https://service.pdok.nl/rvo/nationaleparken/wfs/v2_0?",
       "typeName": "nationaleparken:nationaleparken",
       "version": "2.0.0",
       "maxFeatures": 10,
@@ -107,7 +107,7 @@
       "lid": "pdok-natura2000-wms",
       "format": "image/png",
       "layers": "natura2000",
-      "url": "https://geodata.nationaalgeoregister.nl/natura2000/wms",
+      "url": "https://service.pdok.nl/rvo/natura2000/wms/v1_0",
       "transparent": true,
       "projection": "EPSG:28992",
       "tileGridRef": "dutch_rd",


### PR DESCRIPTION
Sets the current URLs for the PDOK services in the `projected` example app.

Closes #392 