### PR TITLE
Rename remaining Dutch "nationaalgeoregister" PDOK WMTS URLs 

### DIFF
--- a/docs/map-layer-configuration.md
+++ b/docs/map-layer-configuration.md
@@ -129,7 +129,7 @@ Similar properties as Tiled WMS, with these exceptions:
 | Property           | Meaning   | Example |
 |--------------------|:---------:|---------|
 | **type**           | Indicator that the layer is a XYZ tiled image layer, always `XYZ` here  | `"type": "XYZ"` |
-| **url**            | The URL of the service providing the image tiles | `"url": "https://geodata.nationaalgeoregister.nl/tiles/service/wmts/brtachtergrondkaart/EPSG:28992/{z}/{x}/{y}.png"` |
+| **url**            | The URL of the service providing the image tiles | `"url": "https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/{z}/{x}/{y}.png"` |
 | projection         |  The projection of the layer. Has to be defined in `projectionDefs` if not `EPSG:4326` or `EPSG:3857`. if not set the projection of the map is used | `"projection": "EPSG:3857"` |
 | tileGridRef        | Identifier of the tile grid to use for this layer (has to be defined in `tileGridDefs` | `"tileGridRef": "dutch_rd"` |
 | crossOrigin        | Provides support for CORS, defining how the layers source handles crossorigin requests. For more information and the supported values see [HTML attribute: crossorigin](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin)  | `"crossOrigin": "anonymous"` |

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -197,7 +197,7 @@ In a Layer configuration a specific tilegrid can be refered to as follows, using
       "type": "XYZ",
       "lid": "brtachtergrondkaart",
       "name": "WMTS - Topo Basemap - PDOK",
-      "url": "https://geodata.nationaalgeoregister.nl/tiles/service/wmts/brtachtergrondkaart/EPSG:28992/{z}/{x}/{y}.png",
+      "url": "https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/{z}/{x}/{y}.png",
       "projection": "EPSG:28992",
       "tileGridRef": "dutch_rd",
       "visible": true

--- a/tests/unit/specs/components/ol/Map.spec.js
+++ b/tests/unit/specs/components/ol/Map.spec.js
@@ -246,7 +246,7 @@ describe('ol/Map.vue', () => {
         mapLayers: [{
           type: 'XYZ',
           lid: 'brtachtergrondkaart',
-          url: 'https://geodata.nationaalgeoregister.nl/tiles/service/wmts/brtachtergrondkaart/EPSG:28992/{z}/{x}/{y}.png',
+          url: 'https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/{z}/{x}/{y}.png',
           projection: 'EPSG:28992',
           tileGridRef: 'dutch_rd',
           displayInLayerList: true,


### PR DESCRIPTION
This PR relates to issues #226 and #392 (PR #401). 

A [code search](https://github.com/search?q=repo%3Awegue-oss%2Fwegue+nationaalgeoregister&type=code) showed 3 remaining URLs to be adapted in docs and test code. This PR modifies these:

* From: "https://geodata.nationaalgeoregister.nl/tiles/service/wmts/brtachtergrondkaart/EPSG:28992/{z}/{x}/{y}.png"
* To:  "https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/{z}/{x}/{y}.png"
      
See also [PDOK](https://www.pdok.nl/introductie/-/article/basisregistratie-topografie-achtergrondkaarten-brt-a-).