### PR TITLE
Unregister events properly inside AttributeTable component

### DIFF
--- a/src/components/attributeTable/AttributeTable.vue
+++ b/src/components/attributeTable/AttributeTable.vue
@@ -88,6 +88,10 @@ export default {
       // unregister event after table is closed
       this.layer.getSource().un('change', this.prepareTableDataAndColumns);
     }
+
+    if (this.syncTableMapSelection) {
+      this.deactivateSelectRowOnMapClick();
+    }
   },
   watch: {
     layerId () {
@@ -173,6 +177,14 @@ export default {
     },
 
     /**
+     * Deactivate behaviour that a selected feature on the
+     * map will be selected in the AttributeTable as well.
+     */
+    deactivateSelectRowOnMapClick () {
+      WguEventBus.$off('map-selectionchange');
+    },
+
+    /**
      * Highlight row matching the feature ID
      * and set correct page of the table.
      *
@@ -245,6 +257,11 @@ export default {
     populateTable () {
       if (!this.map || !this.layerId) {
         return;
+      }
+
+      // unregister change event on previous layer source if any
+      if (this.layer) {
+        this.layer.getSource().un('change', this.prepareTableDataAndColumns);
       }
 
       // reset table properties


### PR DESCRIPTION
This PR cleanly unregisters the two events that are used inside the AttributeTable component.

One event is called when a feature is selected on the map. This was still registered after the component was closed...

The second is called when the 'onchange' event of the selected layer is fired. This was not cleanly unregistered when changing layers, so selecting a feature of the previously selected layer continued to fire this event and stayed even after the component was closed.

Should be fixed now...