### PR TITLE
Fix Photon geocoder provider

### DIFF
--- a/src/components/geocoder/providers/photon.js
+++ b/src/components/geocoder/providers/photon.js
@@ -23,7 +23,7 @@
 //
 
 /**
- * Photon Provider. See https://photon.komoot.de.
+ * Photon Provider. See https://photon.komoot.io.
  *
  * @class Photon
  */
@@ -33,7 +33,7 @@ export class Photon {
    */
   constructor () {
     this.settings = {
-      url: 'https://photon.komoot.de/api/',
+      url: 'https://photon.komoot.io/api/',
       params: {
         q: '',
         limit: 10,

--- a/src/components/geocoder/providers/photon.js
+++ b/src/components/geocoder/providers/photon.js
@@ -84,6 +84,12 @@ export class Photon {
       // Sometimes has bbox
       if (properties.extent) {
         result.boundingbox = properties.extent;
+        // Ensure bbox is llx,lly,urx,ury
+        if (result.boundingbox[1] > result.boundingbox[3]) {
+          const tmp = result.boundingbox[1];
+          result.boundingbox[1] = result.boundingbox[3];
+          result.boundingbox[3] = tmp;
+        }
       }
       return result;
     });


### PR DESCRIPTION
This PR fixes the Photon geocoder provider. There were two problems with it :

1. The URL has changed four years ago, even though the old one still works, it is a good idea to update it as stated on [photon homepage](https://photon.komoot.io/)
2. Photon returns the bounding boxes with Y coordinates flipped which breaks the move to a selected place. A test was added to put the coordinates in the [format expected by OpenLayers](https://openlayers.org/en/latest/apidoc/module-ol_extent.html#~Extent)