### PR TITLE
HoverController using AbortController instead of cancelToken

### DIFF
--- a/tests/unit/specs/components/ol/HoverController.spec.js
+++ b/tests/unit/specs/components/ol/HoverController.spec.js
@@ -42,7 +42,7 @@ describe('ol/HoverController.js', () => {
       expect(comp.map).to.equal(map);
       expect(comp.timerHandle).to.equal(null);
       expect(comp.activeOverlayId).to.equal(null);
-      expect(comp.pendingRequestsCancelSrc).to.equal(null);
+      expect(comp.pendingRequestsAbortCtrl).to.equal(null);
       expect(comp.conf.delay).to.equal(150)
       expect(comp.conf.hideOnMousemove).to.equal(false)
       expect(comp.conf.hoverOverlay).to.equal('wgu-hover-tooltip')


### PR DESCRIPTION
Current `HoverController` implementation uses axios `cancelToken` to programatically abort requests.  
According to [axios documentation](https://axios-http.com/docs/cancellation), this is now deprecated and a standard `AbortController` object should be used instead.

This PR does just that, it replaces deprecated cancel tokens by abort signals.