### PR TITLE
Corrected InfoClick bug when using MeasureTool afterwards

### DIFF
--- a/src/components/infoclick/InfoClickWin.vue
+++ b/src/components/infoclick/InfoClickWin.vue
@@ -128,7 +128,9 @@ export default {
       me.features = []
       me.map.forEachFeatureAtPixel(evt.pixel,
         (feature, layer) => {
-          me.features.push([feature, layer])
+          if (layer) {
+            me.features.push([feature, layer])
+          }
         });
 
       // collect feature attributes --> PropertyTable

--- a/src/components/infoclick/InfoClickWin.vue
+++ b/src/components/infoclick/InfoClickWin.vue
@@ -66,7 +66,7 @@
 </template>
 
 <script>
-import ModuleCard from './../modulecore/ModuleCard';
+import ModuleCard from '../modulecore/ModuleCard';
 import { WguEventBus } from '../../WguEventBus.js';
 import PropertyTable from './PropertyTable';
 import CoordsTable from './CoordsTable';
@@ -125,18 +125,18 @@ export default {
      */
     onMapClick (evt) {
       const me = this;
-      me.features = []
+      me.features = [];
       me.map.forEachFeatureAtPixel(evt.pixel,
         (feature, layer) => {
           if (layer) {
-            me.features.push([feature, layer])
+            me.features.push([feature, layer]);
           }
         });
 
       // collect feature attributes --> PropertyTable
       if (this.features.length !== 0) {
-        this.featureIdx = 0
-        this.numfeats = me.features.length
+        this.featureIdx = 0;
+        this.numfeats = me.features.length;
         this.viewProps(this.featureIdx)
       } else {
         this.attributeData = null;
@@ -150,19 +150,19 @@ export default {
     },
 
     prevFeat () {
-      this.featureIdx -= 1
+      this.featureIdx -= 1;
       if (this.featureIdx < 0) {
-        this.featureIdx = this.features.length - 1
+        this.featureIdx = this.features.length - 1;
       }
-      this.viewProps(this.featureIdx)
+      this.viewProps(this.featureIdx);
     },
 
     nextFeat () {
-      this.featureIdx += 1
+      this.featureIdx += 1;
       if (this.featureIdx > this.features.length - 1) {
-        this.featureIdx = 0
+        this.featureIdx = 0;
       }
-      this.viewProps(this.featureIdx)
+      this.viewProps(this.featureIdx);
     },
 
     viewProps (idx) {
@@ -171,8 +171,8 @@ export default {
       // do not show geometry property
       delete props.geometry;
       this.attributeData = props;
-      this.layerName = this.features[idx][1].get('name')
-      const lid = this.features[idx][1].get('lid')
+      this.layerName = this.features[idx][1].get('name');
+      const lid = this.features[idx][1].get('lid');
 
       const correspondingInteraction = MapInteractionUtil.getSelectInteraction(this.map, lid);
 

--- a/src/components/infoclick/InfoClickWin.vue
+++ b/src/components/infoclick/InfoClickWin.vue
@@ -197,6 +197,7 @@ export default {
         me.registerMapClick();
       } else {
         // cleanup old data
+        me.registerMapClick(true);
         me.attributeData = null;
         me.coordsData = null;
       }

--- a/tests/unit/specs/components/infoclick/InfoClickWin.spec.js
+++ b/tests/unit/specs/components/infoclick/InfoClickWin.spec.js
@@ -104,15 +104,25 @@ describe('infoclick/InfoClickWin.vue', () => {
     });
 
     it('show registers map click when module is opened', () => {
-      let cnt = 0;
-      const mockFn = () => {
-        cnt++;
-      };
-      vm.registerMapClick = mockFn;
+      const map = new OlMap();
+      vm.map = map;
+      const onSPy = sinon.replace(map, 'on', sinon.fake(map.on));
 
       vm.show(false);
       vm.show(true);
-      expect(cnt).to.equal(1);
+
+      expect(onSPy).to.have.been.calledOnceWithExactly('singleclick', vm.onMapClick);
+    });
+
+    it('show unregisters map click when module is closed', () => {
+      const map = new OlMap();
+      vm.map = map;
+      const unSPy = sinon.replace(map, 'un', sinon.fake(map.un));
+
+      vm.show(true);
+      vm.show(false);
+
+      expect(unSPy).to.have.been.calledOnceWithExactly('singleclick', vm.onMapClick);
     });
   });
 });


### PR DESCRIPTION
Since addition of #367, after `InfoClick` was opened, using some other tools like `MeasureTool` would break at first click on the map.  
This is linked to the fact that the geometry drawn by the measure tool (points and lines) are returned by `forEachFeatureAtPixel`. However, those aren't linked to any layer which made `viewProps` fail in this case.

To correct it, `features` which are not assigned to a layer are not kept by `forEachFeatureAtPixel`.

This PR also corrects another linked bug where the map click event was not unregistered properly when `InfoClick` component was closed. This was apparently reported some time ago. So this also fixes #285 