### PR TITLE
Set version to '3.0.0-dev' in package(-lock).json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wegue",
-  "version": "2.1.0",
+  "version": "3.0.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wegue",
-      "version": "2.1.0",
+      "version": "3.0.0-dev",
       "dependencies": {
         "@vue/compat": "^3.5.13",
         "axios": "^1.7.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wegue",
-  "version": "2.1.0",
+  "version": "3.0.0-dev",
   "description": "Template project for a WebGIS client with OpenLayers and Vue.js",
   "author": "Christian Mayer <chris@meggsimum.de>",
   "contributors": [


### PR DESCRIPTION
Sets the version property to `3.0.0-dev` in `package.json` and `package-lock.json` to clearly transport that the master branch is used for development of upcoming Wegue v3. 