### PR TITLE
Fix featuresloadend and featuresloaderror events not fired properly by WFS layers

### DIFF
--- a/app-starter/static/app-conf-projected.json
+++ b/app-starter/static/app-conf-projected.json
@@ -78,7 +78,7 @@
     {
       "type": "WFS",
       "lid": "dutch-nat-parks",
-      "url": "https://service.pdok.nl/rvo/nationaleparken/wfs/v2_0?",
+      "url": "https://service.pdok.nl/rvo/nationaleparken/wfs/v2_0",
       "typeName": "nationaleparken:nationaleparken",
       "version": "2.0.0",
       "maxFeatures": 10,

--- a/src/factory/Layer.js
+++ b/src/factory/Layer.js
@@ -225,7 +225,7 @@ export const LayerFactory = {
 
     const vectorSource = new VectorSource({
       format: new this.formatMapping[lConf.format](lConf.formatConfig),
-      loader: (extent) => {
+      loader: (extent, resolution, projection, success, failure) => {
         // assemble WFS GetFeature request
         const pre = lConf.url.includes('?') ? '&' : '?';
         let wfsRequest = lConf.url + pre + 'service=WFS&' +
@@ -258,9 +258,11 @@ export const LayerFactory = {
           .then(response => {
             const feats = vectorSource.getFormat().readFeatures(response.data);
             vectorSource.addFeatures(feats);
+            success(feats);
           })
           .catch(() => {
             vectorSource.removeLoadedExtent(extent);
+            failure();
           });
       },
       strategy: lConf.loadOnlyVisible !== false ? bboxStrategy : undefined

--- a/src/factory/Layer.js
+++ b/src/factory/Layer.js
@@ -227,18 +227,21 @@ export const LayerFactory = {
       format: new this.formatMapping[lConf.format](lConf.formatConfig),
       loader: (extent, resolution, projection, success, failure) => {
         // assemble WFS GetFeature request
-        const pre = lConf.url.includes('?') ? '&' : '?';
-        let wfsRequest = lConf.url + pre + 'service=WFS&' +
-          'version=' + lConf.version + '&request=GetFeature&' +
-          'typename=' + lConf.typeName + '&' +
-          'outputFormat=' + outputFormat + '&srsname=' + lConf.projection;
+        const params = {
+          service: 'WFS',
+          version: lConf.version,
+          request: 'GetFeature',
+          typename: lConf.typeName,
+          outputFormat,
+          srsname: lConf.projection
+        };
 
         // add WFS version dependent feature limitation
         if (Number.isInteger(parseInt(lConf.maxFeatures))) {
           if (lConf.version.startsWith('1.')) {
-            wfsRequest += '&maxFeatures=' + lConf.maxFeatures;
+            params.maxFeatures = lConf.maxFeatures;
           } else {
-            wfsRequest += '&count=' + lConf.maxFeatures;
+            params.count = lConf.maxFeatures;
           }
         }
         // add bbox filter
@@ -246,13 +249,14 @@ export const LayerFactory = {
           if (mapSrs !== lConf.projection) {
             extent = applyTransform(extent, getTransform(mapSrs, lConf.projection));
           }
-          wfsRequest += '&bbox=' + extent.join(',') + ',' + lConf.projection + '';
+          params.bbox = extent.join(',') + ',' + lConf.projection;
         }
 
         // load data from WFS, parse and add to vector source
         const request = {
           method: 'GET',
-          url: wfsRequest
+          url: lConf.url,
+          params
         };
         axios(request)
           .then(response => {


### PR DESCRIPTION
There is currently a bug where `featuresloadend` and `featuresloaderror` events are not fired properly by WFS layers.

This is due to missing calls to callback functions inside the underlying `vectorSource` as described inside the [official OpenLayers documentation](https://openlayers.org/en/latest/apidoc/module-ol_source_Vector-VectorSource.html) inside the definition of the `loader` constructor option:

_The `featuresloadend` and `featuresloaderror` events will only fire if the success and failure callbacks are used._

This PR also refactors the WFS layer factory function to use Axios properly. This could have been a separated PR but was included here as it was a mandatory step to make the events firing unit tests writeable...