### PR TITLE
Refactoring of Map Loading Status component

### DIFF
--- a/src/components/progress/MapLoadingStatus.vue
+++ b/src/components/progress/MapLoadingStatus.vue
@@ -11,11 +11,6 @@
 
 <script>
 import { useMap } from '@/composables/Map';
-import {
-  Image as ImageSource, TileImage as TileImageSource,
-  Vector as VectorSource, Cluster as ClusterSource
-} from 'ol/source';
-import LayerGroup from 'ol/layer/Group';
 
 export default {
   name: 'wgu-maploading-status',
@@ -25,7 +20,6 @@ export default {
   },
   data () {
     return {
-      loading: 0,
       visible: false
     }
   },
@@ -45,119 +39,31 @@ export default {
      * and registers the current map layers.
      */
     onMapBound () {
-      this.registerLayers(this.map.getLayerGroup());
+      this.registerMapEvents();
     },
 
     /**
-     * Registers the needed events for the passed layer and takes care
-     * of layer groups by calling itself recursively.
+     * Registers the needed events on the map.
      *
      * @param  {ol/layer/Base | ol/layer/Group} layer Layer or group to register
      */
-    registerLayers (layer) {
-      const me = this;
-
-      if (layer instanceof LayerGroup) {
-        // call ourself recursively
-        const layers = layer.getLayers();
-        layers.forEach(function (child) {
-          me.registerLayers(child);
-        });
-        // handle future changes to this group or stop doing so
-        layers.on('add', me.onLayerAddedToGroup, me);
-        layers.on('remove', me.onLayerRemovedFromGroup, me);
-      } else {
-        const source = layer.getSource();
-        me.bindLoadHandlers(source, true);
-        // reacting on a changed source in a layer
-        layer.on('change:source', function (evt) {
-          me.bindLoadHandlers(evt.target.getSource(), true);
-          me.bindLoadHandlers(evt.oldValue, false);
-        });
-      }
+    registerMapEvents () {
+      this.map.on('loadstart', this.showLoader);
+      this.map.on('loadend', this.hideLoader);
     },
 
     /**
-     * Registers needed events for the passed source and takes care
-     * of sources which do not naturally support load events (`vector`-sources).
-     *
-     * @param  {ol/source/Source} source The layer source to register
+     * Called whenever loading of map data starts.
      */
-    bindLoadHandlers (source, register) {
-      const me = this;
-      let eventPrefix = '';
-      const method = register ? 'on' : 'un';
-
-      if (source instanceof ImageSource) {
-        // includes ImageWms, also e.g. ImageArcGISRest, OSM …
-        eventPrefix = 'image';
-      } else if (source instanceof TileImageSource) {
-        // includes TileWMS, Bing and more
-        eventPrefix = 'tile';
-      } else if (source instanceof VectorSource) {
-        if (source instanceof ClusterSource) {
-          source = source.getSource();
-        }
-        eventPrefix = 'vector';
-      }
-
-      if (eventPrefix) {
-        source[method](eventPrefix + 'loadstart', me.incrementLoading, me);
-        source[method](eventPrefix + 'loadend', me.decrementLoading, me);
-        source[method](eventPrefix + 'loaderror', me.decrementLoading, me);
-      }
+    showLoader () {
+      this.visible = true;
     },
 
     /**
-     * Called whenever loading of a layer starts.
-     * This will increment the internal counter and show this loading indicator.
+     * Called whenever loading of map data has ended.
      */
-    incrementLoading () {
-      const me = this;
-      me.loading++;
-      me.visible = true;
-    },
-
-    /**
-     * Called whenever loading stops or errors.
-     * This will decrement the internal counter and if nothing is currently
-     * loading the counter is reset and the loading indicator is hidden.
-     */
-    decrementLoading () {
-      const me = this;
-      me.loading--;
-
-      if (me.loading <= 0) {
-        me.visible = false;
-        me.resetLoading();
-      }
-    },
-
-    /**
-     * Helper method to reset the internal loading counter.
-     */
-    resetLoading () {
-      this.loading = 0;
-    },
-
-    /**
-     * Takes care of added layers to any `ol/layer/Group`. These need to get
-     * registered to the appropriate handlers.
-     *
-     * @param {ol/events/Event} evt The add event of the `ol/layer/Group`.
-     */
-    onLayerAddedToGroup: function (evt) {
-      this.registerLayers(evt.element);
-    },
-
-    /**
-     * Takes care of removed layers to any `ol/layer/Group`. These need to get
-     * unregistered from the appropriate handlers.
-     *
-     * @param {ol/events/Event} evt The remove event of the `ol/layer/Group`.
-     */
-    onLayerRemovedFromGroup: function (evt) {
-      this.registerLayers(evt.element);
+    hideLoader () {
+      this.visible = false;
     }
   }
 };
@@ -166,11 +72,11 @@ export default {
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style>
 
-  .v-progress-circular.wgu-maploading-status {
-    position: fixed;
-    bottom: 5em;
-    right: 4em;
-    z-index: 1;
-  }
+.v-progress-circular.wgu-maploading-status {
+  position: fixed;
+  bottom: 5em;
+  right: 4em;
+  z-index: 1;
+}
 
 </style>

--- a/tests/unit/specs/components/progress/MapLoadingStatus.spec.js
+++ b/tests/unit/specs/components/progress/MapLoadingStatus.spec.js
@@ -1,9 +1,15 @@
+import { nextTick } from 'vue';
 import { shallowMount } from '@vue/test-utils';
+import { bindMap, unbindMap } from '@/composables/Map';
 import MapLoadingStatus from '@/components/progress/MapLoadingStatus';
+import OlMap from 'ol/Map';
+import OlView from 'ol/View';
+import MapEvent from 'ol/MapEvent';
+import MapEventType from 'ol/MapEventType';
 
 function createWrapper () {
   return shallowMount(MapLoadingStatus);
-}
+};
 
 describe('progress/MapLoadingStatus.vue', () => {
   let comp;
@@ -25,11 +31,115 @@ describe('progress/MapLoadingStatus.vue', () => {
     });
 
     it('has correct default data', () => {
-      expect(vm.loading).to.equal(0);
       expect(vm.visible).to.be.false;
     });
 
     afterEach(() => {
+      comp.unmount();
+    });
+  });
+
+  describe('events', () => {
+    let map;
+
+    beforeEach(() => {
+      map = new OlMap({
+        view: new OlView({
+          center: [0, 0],
+          zoom: 1
+        }),
+        layers: []
+      });
+
+      comp = shallowMount(MapLoadingStatus);
+      vm = comp.vm;
+      bindMap(map);
+    });
+
+    it('hides the circular progress when mounted', done => {
+      // Let time for map to be bound
+      setTimeout(() => {
+        try {
+          const circularProgress = comp.findComponent({ name: 'v-progress-circular' });
+          expect(circularProgress.exists(), 'Circular progress should not be visible').to.be.false;
+          done();
+        } catch (error) {
+          done(error);
+        }
+      }, 100);
+    });
+
+    it('shows the circular progress when map starts loading data', done => {
+      const frameState = {
+        layerStatesArray: []
+      };
+
+      // Let time for map to be bound
+      setTimeout(() => {
+        map.on('loadstart', async () => {
+          nextTick(() => {
+            nextTick(() => {
+              try {
+                const circularProgress = comp.findComponent({ name: 'v-progress-circular' });
+                expect(circularProgress.exists(), 'Circular progress should be visible').to.be.true;
+                done();
+              } catch (error) {
+                done(error);
+              }
+            });
+          })
+        });
+
+        map.dispatchEvent(new MapEvent(MapEventType.LOADSTART, map, frameState))
+      }, 100);
+    });
+
+    it('hides the circular progress when map has finished loading data', done => {
+      const frameState = {
+        layerStatesArray: []
+      };
+
+      // Let time for map to be bound
+      setTimeout(() => {
+        map.on('loadstart', async () => {
+          nextTick(() => {
+            nextTick(() => {
+              try {
+                const circularProgress = comp.findComponent({ name: 'v-progress-circular' });
+                expect(circularProgress.exists(), 'Circular progress should be visible').to.be.true;
+
+                // Send event that should hide the Map Loading Status component
+                map.dispatchEvent(new MapEvent(MapEventType.LOADEND, map, frameState));
+              } catch (error) {
+                done(error);
+              }
+            });
+          });
+        });
+
+        map.on('loadend', () => {
+          nextTick(() => {
+            nextTick(() => {
+              try {
+                const circularProgress = comp.findComponent({ name: 'v-progress-circular' });
+                expect(circularProgress.exists(), 'Circular progress should be hidden').to.be.false;
+                done();
+              } catch (error) {
+                done(error);
+              }
+            });
+          });
+        });
+
+        // Send event that should display the Map Loading Status component
+        map.dispatchEvent(new MapEvent(MapEventType.LOADSTART, map, frameState))
+      }, 100);
+    });
+
+    afterEach(() => {
+      unbindMap();
+      map = undefined;
+
       comp.unmount();
     });
   });


### PR DESCRIPTION
Current implementation of Map Loading Status component has some problems and doesn't detect loading with all and every type of layers.

This is mainly due to the fact that it was written at the time of `OpenLayers 5.3.3` which was released in April 2019 and wasn't upgraded afterwards.

Since `OpenLayers 6.14` (released in March 2022) two map events have been added, `loadstart` and `loadend` which greatly simplifies the job to be done and should be compatible with all upcoming layer types that could be added later.

You can refer to [ahocevar PR](https://github.com/openlayers/openlayers/pull/13491) talking about that.

This PR refactors the Map Loading Status component, using those two events which permits to have a stable behaviour whatever the source and layer types added to the map.

Unit tests are also included for the component.