### PR TITLE
Backport #427: Fix featuresloadend and featuresloaderror events not fired properly by WFS layers

### DIFF
--- a/app-starter/static/app-conf-projected.json
+++ b/app-starter/static/app-conf-projected.json
@@ -78,7 +78,7 @@
     {
       "type": "WFS",
       "lid": "dutch-nat-parks",
-      "url": "https://service.pdok.nl/rvo/nationaleparken/wfs/v2_0?",
+      "url": "https://service.pdok.nl/rvo/nationaleparken/wfs/v2_0",
       "typeName": "nationaleparken:nationaleparken",
       "version": "2.0.0",
       "maxFeatures": 10,

--- a/src/factory/Layer.js
+++ b/src/factory/Layer.js
@@ -3,20 +3,20 @@ import ImageWMS from 'ol/source/ImageWMS';
 import TileWmsSource from 'ol/source/TileWMS';
 import TileArcGISRest from 'ol/source/TileArcGISRest.js';
 import OsmSource from 'ol/source/OSM';
-import VectorTileLayer from 'ol/layer/VectorTile'
-import VectorTileSource from 'ol/source/VectorTile'
-import MvtFormat from 'ol/format/MVT'
-import GeoJsonFormat from 'ol/format/GeoJSON'
-import TopoJsonFormat from 'ol/format/TopoJSON'
-import KmlFormat from 'ol/format/KML'
-import GML2Format from 'ol/format/GML2'
-import GML3Format from 'ol/format/GML3'
-import GML32Format from 'ol/format/GML32'
-import VectorLayer from 'ol/layer/Vector'
-import VectorSource from 'ol/source/Vector'
-import XyzSource from 'ol/source/XYZ'
+import VectorTileLayer from 'ol/layer/VectorTile';
+import VectorTileSource from 'ol/source/VectorTile';
+import MvtFormat from 'ol/format/MVT';
+import GeoJsonFormat from 'ol/format/GeoJSON';
+import TopoJsonFormat from 'ol/format/TopoJSON';
+import KmlFormat from 'ol/format/KML';
+import GML2Format from 'ol/format/GML2';
+import GML3Format from 'ol/format/GML3';
+import GML32Format from 'ol/format/GML32';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import XyzSource from 'ol/source/XYZ';
 import { bbox as bboxStrategy } from 'ol/loadingstrategy';
-import { OlStyleFactory } from './OlStyle'
+import { OlStyleFactory } from './OlStyle';
 import { applyTransform } from 'ol/extent';
 import { getTransform } from 'ol/proj';
 import axios from 'axios';
@@ -227,18 +227,21 @@ export const LayerFactory = {
       format: new this.formatMapping[lConf.format](lConf.formatConfig),
       loader: (extent, resolution, projection, success, failure) => {
         // assemble WFS GetFeature request
-        const pre = lConf.url.includes('?') ? '&' : '?';
-        let wfsRequest = lConf.url + pre + 'service=WFS&' +
-          'version=' + lConf.version + '&request=GetFeature&' +
-          'typename=' + lConf.typeName + '&' +
-          'outputFormat=' + outputFormat + '&srsname=' + lConf.projection;
+        const params = {
+          service: 'WFS',
+          version: lConf.version,
+          request: 'GetFeature',
+          typename: lConf.typeName,
+          outputFormat,
+          srsname: lConf.projection
+        };
 
         // add WFS version dependent feature limitation
         if (Number.isInteger(parseInt(lConf.maxFeatures))) {
           if (lConf.version.startsWith('1.')) {
-            wfsRequest += '&maxFeatures=' + lConf.maxFeatures;
+            params.maxFeatures = lConf.maxFeatures;
           } else {
-            wfsRequest += '&count=' + lConf.maxFeatures;
+            params.count = lConf.maxFeatures;
           }
         }
         // add bbox filter
@@ -246,13 +249,14 @@ export const LayerFactory = {
           if (mapSrs !== lConf.projection) {
             extent = applyTransform(extent, getTransform(mapSrs, lConf.projection));
           }
-          wfsRequest += '&bbox=' + extent.join(',') + ',' + lConf.projection + '';
+          params.bbox = extent.join(',') + ',' + lConf.projection;
         }
 
         // load data from WFS, parse and add to vector source
         const request = {
           method: 'GET',
-          url: wfsRequest
+          url: lConf.url,
+          params
         };
         axios(request)
           .then(response => {

--- a/src/factory/Layer.js
+++ b/src/factory/Layer.js
@@ -225,7 +225,7 @@ export const LayerFactory = {
 
     const vectorSource = new VectorSource({
       format: new this.formatMapping[lConf.format](lConf.formatConfig),
-      loader: (extent) => {
+      loader: (extent, resolution, projection, success, failure) => {
         // assemble WFS GetFeature request
         const pre = lConf.url.includes('?') ? '&' : '?';
         let wfsRequest = lConf.url + pre + 'service=WFS&' +
@@ -258,9 +258,11 @@ export const LayerFactory = {
           .then(response => {
             const feats = vectorSource.getFormat().readFeatures(response.data);
             vectorSource.addFeatures(feats);
+            success(feats);
           })
           .catch(() => {
             vectorSource.removeLoadedExtent(extent);
+            failure();
           });
       },
       strategy: lConf.loadOnlyVisible !== false ? bboxStrategy : undefined

--- a/tests/unit/specs/factory/Layer.spec.js
+++ b/tests/unit/specs/factory/Layer.spec.js
@@ -8,12 +8,15 @@ import VectorTileSource from 'ol/source/VectorTile';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import XyzSource from 'ol/source/XYZ';
-import MvtFormat from 'ol/format/MVT'
-import GeoJsonFormat from 'ol/format/GeoJSON'
-import TopoJsonFormat from 'ol/format/TopoJSON'
-import KmlFormat from 'ol/format/KML'
+import MvtFormat from 'ol/format/MVT';
+import GeoJsonFormat from 'ol/format/GeoJSON';
+import TopoJsonFormat from 'ol/format/TopoJSON';
+import KmlFormat from 'ol/format/KML';
 import Map from 'ol/Map';
 import View from 'ol/View';
+
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
 
 describe('LayerFactory', () => {
   it('is defined', () => {
@@ -183,6 +186,111 @@ describe('LayerFactory', () => {
       const layer = LayerFactory.createVectorTileLayer(layerConf);
       expect(layer instanceof VectorTileLayer).to.equal(true);
       expect(layer.getSource() instanceof VectorTileSource);
+    });
+  });
+
+  describe('WFS layer', () => {
+    describe('Events', () => {
+      let divElement;
+      let wfsLayer;
+      let axiosMock;
+      const layerURL = 'https://a-wfs-url.de';
+      const fetchResults = JSON.stringify({
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            id: '1',
+            geometry: {
+              type: 'Polygon',
+              coordinates: [[4.0, 51.0], [4.5, 50.5], [5.0, 51.0], [4.0, 51.0]]
+            }
+          }
+        ]
+      });
+
+      function createMapTargetElement () {
+        const targetElement = document.createElement('div');
+        targetElement.style.cssText = 'width:640px; height:480px';
+        return targetElement;
+      };
+
+      function applyAxiosMock (error = false) {
+        axiosMock = new MockAdapter(axios);
+        if (!error) {
+          axiosMock.onGet(layerURL).reply(200, fetchResults);
+        } else {
+          axiosMock.onGet(layerURL).networkError();
+        }
+      };
+
+      beforeEach(() => {
+        const layerConf = {
+          type: 'WFS',
+          lid: 'a-wfs',
+          url: layerURL,
+          typeName: 'foo:tn',
+          version: '2.0.0',
+          format: 'GeoJSON',
+          projection: 'EPSG:3857',
+          visible: false
+        };
+
+        divElement = createMapTargetElement();
+        document.body.append(divElement);
+
+        const olMap = new Map({
+          view: new View({
+            center: [0, 0],
+            zoom: 1
+          }),
+          layers: [],
+          target: divElement
+        });
+        wfsLayer = LayerFactory.createWfsLayer(layerConf, olMap);
+        olMap.addLayer(wfsLayer);
+      });
+
+      it('fires the featuresloadstart event when displayed', done => {
+        applyAxiosMock();
+
+        wfsLayer.getSource().on('featuresloadstart', () => {
+          done();
+        })
+
+        wfsLayer.setVisible(true);
+      });
+
+      it('fires the featuresloadend event when features retrieved', done => {
+        applyAxiosMock();
+
+        wfsLayer.getSource().on('featuresloadend', () => {
+          done();
+        })
+
+        wfsLayer.setVisible(true);
+      });
+
+      it('fires the featuresloaderror event when error during features retrieval', done => {
+        applyAxiosMock(true);
+
+        wfsLayer.getSource().on('featuresloaderror', () => {
+          done();
+        })
+
+        wfsLayer.setVisible(true);
+      });
+
+      afterEach(() => {
+        if (axiosMock) {
+          axiosMock.restore();
+        }
+
+        if (divElement) {
+          divElement.remove();
+          divElement = undefined;
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
This PR backports #427 fix on the `v2` branch.

Fixes #429